### PR TITLE
fix: stabilization phase 1 - bugs and dependency updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   pull_request:
     branches:
       - main
@@ -12,24 +12,15 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
-        with:
-          command: test
-          args: --all-features --no-fail-fast
-        env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-      - uses: actions-rs/grcov@770fa904bcbfc50da498080d1511da7388e6ddc6
-        with:
-          config: configs/grcov.yml
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
       - name: Coveralls upload
-        uses: coverallsapp/github-action@9ba913c152ae4be1327bfb9085dc806cedb44057
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ github.workspace }}/lcov.info
+          file: lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,17 @@ license = "MIT"
 
 [dependencies]
 log = "0.4"
-env_logger = "0.9"
+env_logger = "0.11"
 anyhow = "1.0"
-assert_cmd = "2.0"
 chrono = "0.4"
-clokwerk = "0.3.5"
-git2 = "0.13"
-predicates = "2.1"
-structopt = "0.3"
-url = "2.2"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
+clokwerk = "0.4"
+git2 = "0.20"
+clap = { version = "4", features = ["derive"] }
+url = "2"
+uuid = { version = "1", features = ["serde", "v4"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
-run_script = { version = "0.9" }
+run_script = "0.11"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,46 +1,44 @@
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Action {
     /// Spy a remote git repo for changes, will continuously execute defined script/command on a diff
     Spy {
         /// The remote git repo to watch for changes
-        #[structopt()]
         url: String,
         /// The branch of the remote git repo to watch for changes
-        #[structopt(short, long, default_value = "main")]
+        #[arg(short, long, default_value = "main")]
         branch: String,
         /// The time between checks in seconds, max 65535
-        #[structopt(short, long, default_value = "120")]
+        #[arg(short, long, default_value = "120")]
         delay: u16,
         /// Username, owner of the token - required for private repos
-        #[structopt(short, long)]
+        #[arg(short, long)]
         username: Option<String>,
         /// The access token for cloning and fetching of the remote repo
-        #[structopt(short, long)]
+        #[arg(short, long)]
         token: Option<String>,
         /// The command to run when a change is detected
-        #[structopt(short, long, default_value = "")]
+        #[arg(short, long, default_value = "")]
         command: String,
         /// Adjust level of stdout, 0 no goa output , max 2 (debug)
-        #[structopt(short, long, default_value = "1")]
+        #[arg(short, long, default_value = "1")]
         verbosity: u8,
         /// Execute the command, or .goa file, on start
-        #[structopt(short, long)]
+        #[arg(short, long)]
         exec_on_start: bool,
         /// Exit immediately after first diff spied
-        #[structopt(short = "x", long)]
+        #[arg(short = 'x', long)]
         exit_on_first_diff: bool,
         /// The target path for the clone
-        #[structopt(short = "T", long)]
+        #[arg(short = 'T', long)]
         target_path: Option<String>,
     },
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "goa", about = "A command-line GitOps utility agent")]
-
+#[derive(Debug, Parser)]
+#[command(name = "goa", about = "A command-line GitOps utility agent")]
 pub struct CommandLineArgs {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     pub action: Action,
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,10 +12,10 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use git2::{
     AutotagOption, Commit, Diff, DiffStatsFormat, FetchOptions, Object, ObjectType,
-    RemoteCallbacks, Repository,
+    RemoteCallbacks, RemoteUpdateFlags, Repository,
 };
 use std::env;
 use std::io::Write;
@@ -33,7 +33,7 @@ pub fn is_diff<'a>(
         .or_else(|_| repo.remote_anonymous(remote_name))
         .unwrap();
     cb.sideband_progress(|data| {
-        if verbosity > 2 {
+        if verbosity >= 2 {
             let dt = Utc::now();
             print!(
                 "goa [{}]: remote: {}",
@@ -57,7 +57,7 @@ pub fn is_diff<'a>(
     // which can happen e.g. when the branches have been changed but all the
     // needed objects are available locally.
     remote
-        .update_tips(None, true, AutotagOption::Unspecified, None)
+        .update_tips(None, RemoteUpdateFlags::UPDATE_FETCHHEAD, AutotagOption::Unspecified, None)
         .unwrap();
 
     let l = String::from(branch_name);
@@ -88,7 +88,7 @@ pub fn is_diff<'a>(
 
     if diff.deltas().len() > 0 {
         // TODO: make this a verbose thing
-        if verbosity > 2 {
+        if verbosity >= 2 {
             display_stats(&diff).expect("ERROR: unable to print diff stats");
         }
         let fetch_head = repo.find_reference("FETCH_HEAD")?;
@@ -128,7 +128,7 @@ fn display_stats(diff: &Diff) -> Result<(), git2::Error> {
     let format = DiffStatsFormat::FULL;
     let buf = stats.to_buf(format, 80).unwrap();
     let dt = Utc::now();
-    print!("goa [{}]: {}", dt, std::str::from_utf8(&*buf).unwrap());
+    print!("goa [{}]: {}", dt, std::str::from_utf8(&buf).unwrap());
     Ok(())
 }
 
@@ -154,7 +154,7 @@ fn find_last_commit_on_branch<'a>(
         .map_err(|_| git2::Error::from_str("Couldn't find commit"))
 }
 
-fn find_last_commit(repo: &Repository) -> Result<Commit, git2::Error> {
+fn find_last_commit(repo: &Repository) -> Result<Commit<'_>, git2::Error> {
     let obj = repo.head()?.resolve()?.peel(ObjectType::Commit)?;
     obj.into_commit()
         .map_err(|_| git2::Error::from_str("Couldn't find commit"))
@@ -162,7 +162,7 @@ fn find_last_commit(repo: &Repository) -> Result<Commit, git2::Error> {
 
 fn commit_to_envs(commit: &Commit, verbosity: u8) {
     let timestamp = commit.time().seconds();
-    let tm = NaiveDateTime::from_timestamp(timestamp, 0);
+    let tm = DateTime::from_timestamp(timestamp, 0).unwrap_or_else(Utc::now);
     if verbosity > 0 {
         let dt = Utc::now();
         println!(
@@ -176,7 +176,10 @@ fn commit_to_envs(commit: &Commit, verbosity: u8) {
     }
     env::set_var("GOA_LAST_COMMIT_ID", commit.id().to_string());
     env::set_var("GOA_LAST_COMMIT_AUTHOR", commit.author().to_string());
-    env::set_var("GOA_LAST_COMMIT_MESSAGE", commit.author().to_string());
+    env::set_var(
+        "GOA_LAST_COMMIT_MESSAGE",
+        commit.message().unwrap_or(""),
+    );
     env::set_var("GOA_LAST_COMMIT_TIME", tm.to_string());
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod repos;
 mod spy;
 
 use crate::repos::Repo;
+use clap::Parser;
 use cli::{Action::*, CommandLineArgs};
-use structopt::StructOpt;
 
 #[macro_use]
 extern crate log;
@@ -13,7 +13,7 @@ extern crate log;
 use env_logger::{Builder, Env, Target};
 
 fn main() -> anyhow::Result<()> {
-    let CommandLineArgs { action } = CommandLineArgs::from_args();
+    let CommandLineArgs { action } = CommandLineArgs::parse();
 
     match action {
         Spy {

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,4 +1,4 @@
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, Result};
 use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -20,6 +20,7 @@ pub struct Repo {
     pub url: String,
     pub username: Option<String>,
     pub token: Option<String>,
+    #[allow(dead_code)] // TODO: Issue #11 - store run count and timestamps
     pub status: Option<String>,
     pub local_path: Option<String>,
     pub branch: String,
@@ -126,12 +127,12 @@ pub fn read_goa_file(goa_path: String) -> String {
 }
 
 pub fn do_process_once(repo: &mut Repo) -> Result<()> {
-    let local_repo = match Repository::open(&repo.local_path.as_ref().unwrap()) {
+    let local_repo = match Repository::open(repo.local_path.as_ref().unwrap()) {
         Ok(local_repo) => local_repo,
         Err(e) => {
             eprintln!("goa error: failed to open the cloned repo");
             //std::process::exit(1);
-            return Err(Error::new(ErrorKind::Other, e.to_string()));
+            return Err(Error::other(e.to_string()));
         }
     };
 
@@ -160,12 +161,12 @@ pub fn do_process_once(repo: &mut Repo) -> Result<()> {
 
 pub fn do_process(repo: &mut Repo) -> Result<()> {
     // Get the real Repository
-    let local_repo = match Repository::open(&repo.local_path.as_ref().unwrap()) {
+    let local_repo = match Repository::open(repo.local_path.as_ref().unwrap()) {
         Ok(local_repo) => local_repo,
         Err(e) => {
             eprintln!("goa error: failed to open the cloned repo");
             //std::process::exit(1);
-            return Err(Error::new(ErrorKind::Other, e.to_string()));
+            return Err(Error::other(e.to_string()));
         }
     };
 
@@ -259,6 +260,7 @@ fn do_task(repo: &mut Repo) -> Result<String> {
 #[cfg(test)]
 mod repos_tests {
     use super::*;
+    use std::io::ErrorKind;
 
     #[test]
     fn test_creation_of_repo() {

--- a/src/spy/mod.rs
+++ b/src/spy/mod.rs
@@ -35,7 +35,7 @@ pub fn spy_repo(mut repo: Repo) -> Result<()> {
         }
     };
 
-    if repo.local_path == None {
+    if repo.local_path.is_none() {
         // Get a temp directory to do work in
         let temp_dir = temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -22,7 +22,7 @@ fn test_spy_repo_command_bad_url() -> Result<(), Box<dyn std::error::Error>> {
 fn test_spy_repo_command_missing_auth() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");
-    cmd.arg("https://github.com/kitplummer/cliban");
+    cmd.arg("https://github.com/kitplummer/hive-node");
     cmd.assert()
         //.failure()
         .stderr(predicates::str::contains(
@@ -39,7 +39,7 @@ fn test_spy_repo_command_bad_auth() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("fred");
     cmd.arg("-t");
     cmd.arg("flintstone");
-    cmd.arg("https://github.com/kitplummer/cliban");
+    cmd.arg("https://github.com/kitplummer/hive-node");
     cmd.assert().stderr(predicates::str::contains(
         "goa error: failed to clone -> remote authentication required",
     ));


### PR DESCRIPTION
## Summary

- Fix `GOA_LAST_COMMIT_MESSAGE` bug — was setting author name instead of commit message
- Fix verbosity check — `> 2` changed to `>= 2` so debug output works at `-v 2`
- Migrate `structopt` → `clap 4` with derive macros (structopt is maintenance-only)
- Update `git2` 0.13 → 0.20 (includes `RemoteUpdateFlags` API change)
- Update `uuid` 0.8 → 1.x
- Update `env_logger` 0.9 → 0.11  
- Update `clokwerk` 0.3 → 0.4
- Update `run_script` 0.9 → 0.11
- Update chrono timestamp API (deprecated `NaiveDateTime::from_timestamp`)
- Fix auth tests to use guaranteed-private repo (`hive-node`)
- Apply clippy fixes and clean up warnings
- Move test dependencies to `[dev-dependencies]`

## Test plan

- [x] All 15 tests pass (6 unit + 9 integration)
- [x] Clippy clean
- [x] Builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)