### PR TITLE
fix: replace unwrap/process::exit with proper error handling

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -30,66 +30,68 @@ pub fn is_diff<'a>(
     let mut cb = RemoteCallbacks::new();
     let mut remote = repo
         .find_remote(remote_name)
-        .or_else(|_| repo.remote_anonymous(remote_name))
-        .unwrap();
+        .or_else(|_| repo.remote_anonymous(remote_name))?;
+
     cb.sideband_progress(|data| {
         if verbosity >= 2 {
             let dt = Utc::now();
-            print!(
-                "goa [{}]: remote: {}",
-                dt,
-                std::str::from_utf8(data).unwrap()
-            );
+            if let Ok(msg) = std::str::from_utf8(data) {
+                print!("goa [{}]: remote: {}", dt, msg);
+            }
         }
-        std::io::stdout().flush().unwrap();
+        let _ = std::io::stdout().flush();
         true
     });
 
     let mut fo = FetchOptions::new();
     fo.remote_callbacks(cb);
-    remote.download(&[] as &[&str], Some(&mut fo)).unwrap();
+    remote.download(&[] as &[&str], Some(&mut fo))?;
 
     // Disconnect the underlying connection to prevent from idling.
-    remote.disconnect().unwrap();
+    remote.disconnect()?;
 
     // Update the references in the remote's namespace to point to the right
     // commits. This may be needed even if there was no packfile to download,
     // which can happen e.g. when the branches have been changed but all the
     // needed objects are available locally.
-    remote
-        .update_tips(None, RemoteUpdateFlags::UPDATE_FETCHHEAD, AutotagOption::Unspecified, None)
-        .unwrap();
+    remote.update_tips(
+        None,
+        RemoteUpdateFlags::UPDATE_FETCHHEAD,
+        AutotagOption::Unspecified,
+        None,
+    )?;
 
     let l = String::from(branch_name);
     let r = format!("{}/{}", remote_name, branch_name);
-    let tl = tree_to_treeish(repo, Some(&l)).unwrap();
-    let tr = tree_to_treeish(repo, Some(&r)).unwrap();
+    let tl = tree_to_treeish(repo, Some(&l))?;
+    let tr = tree_to_treeish(repo, Some(&r))?;
 
-    let head = repo.head().unwrap();
-    let oid = head.target().unwrap();
-    let commit = repo.find_commit(oid).unwrap();
+    let head = repo.head()?;
+    let oid = head
+        .target()
+        .ok_or_else(|| git2::Error::from_str("HEAD has no target"))?;
+    let commit = repo.find_commit(oid)?;
 
     let _branch = repo.branch(branch_name, &commit, false);
 
-    let obj = repo
-        .revparse_single(&("refs/heads/".to_owned() + branch_name))
-        .unwrap();
+    let obj = repo.revparse_single(&("refs/heads/".to_owned() + branch_name))?;
 
     repo.checkout_tree(&obj, None)?;
 
     repo.set_head(&("refs/heads/".to_owned() + branch_name))?;
 
     let diff = match (tl, tr) {
-        (Some(local), Some(origin)) => repo
-            .diff_tree_to_tree(local.as_tree(), origin.as_tree(), None)
-            .unwrap(),
-        (_, _) => unreachable!(),
+        (Some(local), Some(origin)) => {
+            repo.diff_tree_to_tree(local.as_tree(), origin.as_tree(), None)?
+        }
+        (_, _) => return Err(git2::Error::from_str("Could not resolve local or remote tree")),
     };
 
     if diff.deltas().len() > 0 {
-        // TODO: make this a verbose thing
         if verbosity >= 2 {
-            display_stats(&diff).expect("ERROR: unable to print diff stats");
+            if let Err(e) = display_stats(&diff) {
+                eprintln!("Warning: unable to print diff stats: {}", e);
+            }
         }
         let fetch_head = repo.find_reference("FETCH_HEAD")?;
         repo.reference_to_annotated_commit(&fetch_head)
@@ -99,9 +101,14 @@ pub fn is_diff<'a>(
     }
 }
 
-pub fn set_last_commit(repo: &git2::Repository, branch_name: &str, verbosity: u8) {
-    let commit = find_last_commit_on_branch(repo, branch_name);
-    commit_to_envs(&commit.unwrap(), verbosity);
+pub fn set_last_commit(
+    repo: &git2::Repository,
+    branch_name: &str,
+    verbosity: u8,
+) -> Result<(), git2::Error> {
+    let commit = find_last_commit_on_branch(repo, branch_name)?;
+    commit_to_envs(&commit, verbosity);
+    Ok(())
 }
 
 pub fn tree_to_treeish<'a>(
@@ -112,23 +119,21 @@ pub fn tree_to_treeish<'a>(
         Some(s) => s,
         None => return Ok(None),
     };
-    let obj = match repo.revparse_single(arg) {
-        Ok(obj) => obj,
-        Err(_) => {
-            eprintln!("Error: branch not found");
-            std::process::exit(1);
-        }
-    };
-    let tree = obj.peel(ObjectType::Tree).unwrap();
+    let obj = repo.revparse_single(arg).map_err(|e| {
+        git2::Error::from_str(&format!("branch '{}' not found: {}", arg, e))
+    })?;
+    let tree = obj.peel(ObjectType::Tree)?;
     Ok(Some(tree))
 }
 
 fn display_stats(diff: &Diff) -> Result<(), git2::Error> {
-    let stats = diff.stats().unwrap();
+    let stats = diff.stats()?;
     let format = DiffStatsFormat::FULL;
-    let buf = stats.to_buf(format, 80).unwrap();
+    let buf = stats.to_buf(format, 80)?;
     let dt = Utc::now();
-    print!("goa [{}]: {}", dt, std::str::from_utf8(&buf).unwrap());
+    if let Ok(s) = std::str::from_utf8(&buf) {
+        print!("goa [{}]: {}", dt, s);
+    }
     Ok(())
 }
 
@@ -136,18 +141,21 @@ fn find_last_commit_on_branch<'a>(
     repo: &'a Repository,
     branch_name: &str,
 ) -> Result<Commit<'a>, git2::Error> {
-    let (object, reference) = repo.revparse_ext(branch_name).expect("Object not found");
+    let (object, reference) = repo.revparse_ext(branch_name)?;
 
-    repo.checkout_tree(&object, None)
-        .expect("Failed to checkout");
+    repo.checkout_tree(&object, None)?;
 
     match reference {
         // gref is an actual reference like branches or tags
-        Some(gref) => repo.set_head(gref.name().unwrap()),
+        Some(gref) => {
+            let name = gref
+                .name()
+                .ok_or_else(|| git2::Error::from_str("Reference has no name"))?;
+            repo.set_head(name)?;
+        }
         // this is a commit, not a reference
-        None => repo.set_head_detached(object.id()),
+        None => repo.set_head_detached(object.id())?,
     }
-    .expect("Failed to set HEAD");
 
     let obj = repo.head()?.resolve()?.peel(ObjectType::Commit)?;
     obj.into_commit()
@@ -278,13 +286,13 @@ pub fn do_merge<'a>(
                 ))?;
             }
         };
-        let commit = find_last_commit(repo).expect("Couldn't find last commit");
+        let commit = find_last_commit(repo)?;
         commit_to_envs(&commit, verbosity);
     } else if analysis.0.is_normal() {
         // do a normal merge
         let head_commit = repo.reference_to_annotated_commit(&repo.head()?)?;
         normal_merge(repo, &head_commit, &fetch_commit)?;
-        let commit = find_last_commit(repo).expect("Couldn't find last commit");
+        let commit = find_last_commit(repo)?;
         commit_to_envs(&commit, verbosity);
     } else {
         eprintln!("Error: Nothing to do?");

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -62,26 +62,29 @@ impl Repo {
         }
     }
 
-    pub fn clone_repo(&self) {
+    pub fn clone_repo(&self) -> Result<()> {
+        let local_path = self
+            .local_path
+            .as_ref()
+            .ok_or_else(|| Error::other("local_path is not set"))?;
+
         // Some OS-specific non-sense with trailing / in paths
-        let local_target = str::replace(self.local_path.as_ref().unwrap(), "//", "/");
+        let local_target = str::replace(local_path, "//", "/");
         match Repository::clone(self.url.as_str(), local_target) {
             Ok(_repo) => {
                 if self.verbosity > 0 {
-                    info!(
-                        "cloned remote repo to {}",
-                        self.local_path.as_ref().unwrap()
-                    );
+                    info!("cloned remote repo to {}", local_path);
                 }
+                Ok(())
             }
             Err(e) => {
-                eprintln!("goa error: failed to clone -> {}", e);
-                std::process::exit(1);
+                let msg = format!("goa error: failed to clone -> {}", e);
+                Err(Error::other(msg))
             }
-        };
+        }
     }
 
-    pub fn spy_for_changes(&self) {
+    pub fn spy_for_changes(&self) -> Result<()> {
         if self.verbosity > 0 {
             info!("checking for diffs every {} seconds", self.delay);
         }
@@ -90,24 +93,36 @@ impl Repo {
         let mut scheduler = Scheduler::new();
         let delay = self.delay as u32;
         let cloned_repo = Arc::new(Mutex::new(self.clone()));
+
         if self.exec_on_start {
-            let mut mut_repo = cloned_repo.lock().unwrap();
+            let mut mut_repo = cloned_repo
+                .lock()
+                .map_err(|e| Error::other(format!("Failed to acquire lock: {}", e)))?;
             match do_process_once(mut_repo.deref_mut()) {
                 Ok(()) => {
                     if self.verbosity > 0 {
                         info!("exec on startup complete");
                     }
                 }
-                Err(_e) => {
-                    eprintln!("goa error: failed to exec on startup");
+                Err(e) => {
+                    // exec_on_start failure is fatal - return the error
+                    return Err(Error::other(format!("failed to exec on startup: {}", e)));
                 }
             }
         }
 
         // Add the repo to scheduler
         scheduler.every(delay.seconds()).run(move || {
-            let mut mut_repo = cloned_repo.lock().unwrap();
-            do_process(mut_repo.deref_mut()).expect("Error: unable to attach to local repo.")
+            match cloned_repo.lock() {
+                Ok(mut mut_repo) => {
+                    if let Err(e) = do_process(mut_repo.deref_mut()) {
+                        eprintln!("goa error: unable to process repo: {}", e);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("goa error: failed to acquire lock: {}", e);
+                }
+            }
         });
 
         // Manually run the scheduler in an event loop
@@ -120,30 +135,35 @@ impl Repo {
 
 pub fn read_goa_file(goa_path: String) -> String {
     if std::path::Path::new(&goa_path).exists() {
-        std::fs::read_to_string(goa_path).unwrap()
+        std::fs::read_to_string(goa_path).unwrap_or_else(|_| {
+            String::from("echo 'failed to read .goa file'")
+        })
     } else {
         String::from("echo 'no goa file found yet'")
     }
 }
 
 pub fn do_process_once(repo: &mut Repo) -> Result<()> {
-    let local_repo = match Repository::open(repo.local_path.as_ref().unwrap()) {
-        Ok(local_repo) => local_repo,
-        Err(e) => {
-            eprintln!("goa error: failed to open the cloned repo");
-            //std::process::exit(1);
-            return Err(Error::other(e.to_string()));
-        }
-    };
+    let local_path = repo
+        .local_path
+        .as_ref()
+        .ok_or_else(|| Error::other("local_path is not set"))?;
 
-    git::set_last_commit(&local_repo, &repo.branch.to_string(), repo.verbosity);
+    let local_repo = Repository::open(local_path).map_err(|e| {
+        Error::other(format!("goa error: failed to open the cloned repo: {}", e))
+    })?;
+
+    git::set_last_commit(&local_repo, &repo.branch, repo.verbosity).map_err(|e| {
+        Error::other(format!("branch '{}' not found: {}", repo.branch, e))
+    })?;
 
     if repo.command.is_empty() {
-        repo.command = read_goa_file(format!("{}/.goa", repo.local_path.as_ref().unwrap()));
+        repo.command = read_goa_file(format!("{}/.goa", local_path));
         if repo.verbosity > 2 {
             debug!(".goa file command {}", repo.command);
         }
     }
+
     match do_task(repo) {
         Ok(output) => {
             if repo.verbosity > 0 {
@@ -160,32 +180,26 @@ pub fn do_process_once(repo: &mut Repo) -> Result<()> {
 }
 
 pub fn do_process(repo: &mut Repo) -> Result<()> {
-    // Get the real Repository
-    let local_repo = match Repository::open(repo.local_path.as_ref().unwrap()) {
-        Ok(local_repo) => local_repo,
-        Err(e) => {
-            eprintln!("goa error: failed to open the cloned repo");
-            //std::process::exit(1);
-            return Err(Error::other(e.to_string()));
-        }
-    };
+    let local_path = repo
+        .local_path
+        .as_ref()
+        .ok_or_else(|| Error::other("local_path is not set"))?
+        .clone();
+
+    let local_repo = Repository::open(&local_path).map_err(|e| {
+        Error::other(format!("goa error: failed to open the cloned repo: {}", e))
+    })?;
 
     if repo.verbosity > 1 {
         info!("checking for diffs at origin/{}!", repo.branch);
     }
 
-    match git::is_diff(
-        &local_repo,
-        "origin",
-        &repo.branch.to_string(),
-        repo.verbosity,
-    ) {
+    match git::is_diff(&local_repo, "origin", &repo.branch, repo.verbosity) {
         Ok(commit) => {
             match git::do_merge(&local_repo, &repo.branch, commit, repo.verbosity) {
                 Ok(()) => {
                     if repo.command.is_empty() {
-                        repo.command =
-                            read_goa_file(format!("{}/.goa", repo.local_path.as_ref().unwrap()));
+                        repo.command = read_goa_file(format!("{}/.goa", local_path));
                         if repo.verbosity > 2 {
                             debug!(".goa file command {}", repo.command);
                         }
@@ -199,6 +213,7 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
                             }
 
                             if repo.exit_on_first_diff {
+                                // Intentional exit after first diff processed
                                 std::process::exit(0);
                             }
                         }
@@ -227,21 +242,28 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
 }
 
 fn do_task(repo: &mut Repo) -> Result<String> {
+    let local_path = repo
+        .local_path
+        .as_ref()
+        .ok_or_else(|| Error::other("local_path is not set"))?;
+
     let command: Vec<&str> = repo.command.split(' ').collect();
 
     if repo.verbosity > 1 {
         info!("running -> {:?}", command);
     }
+
     let mut options = ScriptOptions::new();
-    options.working_directory = Some(PathBuf::from(&repo.local_path.as_ref().unwrap()));
+    options.working_directory = Some(PathBuf::from(local_path));
 
     let args = vec![];
 
     // run the script and get the script execution output
-    let (code, output, error) = run_script::run(&repo.command, &args, &options).unwrap();
+    let (code, output, error) = run_script::run(&repo.command, &args, &options)
+        .map_err(|e| Error::other(format!("Failed to run script: {}", e)))?;
 
     if repo.verbosity > 2 {
-        debug!("path -> {}", &repo.local_path.as_ref().unwrap());
+        debug!("path -> {}", local_path);
     }
 
     if repo.verbosity > 1 {
@@ -250,7 +272,8 @@ fn do_task(repo: &mut Repo) -> Result<String> {
     }
 
     if !error.is_empty() {
-        eprintln!("goa error: {}", error);
+        eprintln!("{}", error);
+        // Exit with the command's exit code - this is intentional behavior
         std::process::exit(code);
     }
 
@@ -306,7 +329,7 @@ mod repos_tests {
         let temp_dir = std::env::temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
         let tmp_dir_name = format!("/{}/", uuid::Uuid::new_v4());
-        local_path.push_str(&String::from(tmp_dir_name));
+        local_path.push_str(&tmp_dir_name);
         let mut repo = Repo::new(
             String::from("https://github.com/kitplummer/goa_tester"),
             Some(String::from("")),
@@ -321,7 +344,7 @@ mod repos_tests {
             false,
         );
 
-        repo.clone_repo();
+        repo.clone_repo()?;
 
         assert_eq!(do_process(&mut repo)?, ());
         Ok(())
@@ -332,7 +355,7 @@ mod repos_tests {
         let temp_dir = std::env::temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
         let tmp_dir_name = format!("/{}/", uuid::Uuid::new_v4());
-        local_path.push_str(&String::from(tmp_dir_name));
+        local_path.push_str(&tmp_dir_name);
         let mut repo = Repo::new(
             String::from("https://github.com/kitplummer/goa_tester"),
             Some(String::from("")),
@@ -347,7 +370,7 @@ mod repos_tests {
             false,
         );
 
-        repo.clone_repo();
+        repo.clone_repo()?;
         repo.local_path = Some(String::from("/blahdyblahblah"));
         let res = do_process(&mut repo).unwrap_err();
         assert_eq!(res.kind(), ErrorKind::Other);
@@ -360,7 +383,7 @@ mod repos_tests {
         let temp_dir = std::env::temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
         let tmp_dir_name = format!("/{}/", uuid::Uuid::new_v4());
-        local_path.push_str(&String::from(tmp_dir_name));
+        local_path.push_str(&tmp_dir_name);
         println!("local_path: {:?}", local_path);
         let mut repo = Repo::new(
             String::from("https://github.com/kitplummer/goa_tester"),
@@ -376,7 +399,7 @@ mod repos_tests {
             false,
         );
 
-        repo.clone_repo();
+        repo.clone_repo()?;
 
         assert_eq!(do_process(&mut repo)?, ());
         Ok(())

--- a/src/spy/mod.rs
+++ b/src/spy/mod.rs
@@ -1,5 +1,5 @@
 use std::env::temp_dir;
-use std::io::Result;
+use std::io::{Error, Result};
 
 use url::Url;
 use uuid::Uuid;
@@ -14,43 +14,41 @@ pub fn spy_repo(mut repo: Repo) -> Result<()> {
     repo.url = match Url::parse(&repo.url) {
         Ok(mut parsed_url) => {
             if let Some(ref username) = repo.username {
-                if let Err(e) = parsed_url.set_username(username) {
-                    eprintln!("goa error: {:?}", e);
-                    std::process::exit(1);
-                };
+                parsed_url
+                    .set_username(username)
+                    .map_err(|_| Error::other("Failed to set username in URL"))?;
             }
 
             if let Some(ref token) = repo.token {
-                let token_str: &str = &token[..];
-                if let Err(e) = parsed_url.set_password(Option::from(token_str)) {
-                    eprintln!("goa error: {:?}", e);
-                    std::process::exit(1);
-                };
+                parsed_url
+                    .set_password(Some(token))
+                    .map_err(|_| Error::other("Failed to set password in URL"))?;
             }
             parsed_url.to_string()
         }
         Err(e) => {
-            eprintln!("goa error: invalid URL or path, {}", e);
-            std::process::exit(1);
+            return Err(Error::other(format!("goa error: invalid URL or path, {}", e)));
         }
     };
 
     if repo.local_path.is_none() {
         // Get a temp directory to do work in
-        let temp_dir = temp_dir();
-        let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
-        let tmp_dir_name = format!("/{}/", Uuid::new_v4());
-        local_path.push_str(&tmp_dir_name);
+        let temp = temp_dir();
+        let local_path = temp
+            .into_os_string()
+            .into_string()
+            .map_err(|_| Error::other("Failed to convert temp directory path to string"))?;
+        let tmp_dir_name = format!("{}/{}/", local_path, Uuid::new_v4());
 
         // Set the local repo path in the repo struct
-        repo.local_path = Some(local_path);
+        repo.local_path = Some(tmp_dir_name);
     }
 
     // Clone the repo and set the local path
-    repo.clone_repo();
+    repo.clone_repo()?;
 
     // This is where the loop happens...
-    repo.spy_for_changes();
+    repo.spy_for_changes()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Convert all `unwrap()` calls in production code to `?` operator or proper error handling
- `git.rs`: Git operations return `Result`, callbacks handle errors gracefully  
- `repos.rs`: `clone_repo()` and `spy_for_changes()` now return `Result`
- `spy/mod.rs`: URL parsing returns proper errors instead of `process::exit()`
- Scheduler callbacks log errors instead of panicking
- `exec_on_start` failure is now fatal (returns error instead of continuing silently)

**Before:** 71 `unwrap()` calls, 9 `process::exit()` calls
**After:** 0 `unwrap()` in production code (4 in test code), 2 intentional exits

**Intentional exits retained:**
- `exit(0)` for `-x` flag (exit on first diff) — documented feature
- `exit(code)` to propagate command exit codes — expected behavior

## Test plan

- [x] All 15 tests pass (6 unit + 9 integration)
- [x] Clippy clean
- [x] `test_spy_repo_command_bad_branch` verifies error propagation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)