### PR TITLE
refactor: thread-safe environment variable passing

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -17,9 +17,31 @@ use git2::{
     AutotagOption, Commit, Diff, DiffStatsFormat, FetchOptions, Object, ObjectType,
     RemoteCallbacks, RemoteUpdateFlags, Repository,
 };
-use std::env;
+use std::collections::HashMap;
 use std::io::Write;
 use std::str;
+
+/// Metadata extracted from a git commit, to be passed to child processes as env vars.
+/// This avoids global env var mutation which is not thread-safe.
+#[derive(Debug, Clone, Default)]
+pub struct CommitMetadata {
+    pub id: String,
+    pub author: String,
+    pub message: String,
+    pub time: String,
+}
+
+impl CommitMetadata {
+    /// Convert to a HashMap suitable for passing to child process environment
+    pub fn to_env_vars(&self) -> HashMap<String, String> {
+        let mut vars = HashMap::new();
+        vars.insert("GOA_LAST_COMMIT_ID".to_string(), self.id.clone());
+        vars.insert("GOA_LAST_COMMIT_AUTHOR".to_string(), self.author.clone());
+        vars.insert("GOA_LAST_COMMIT_MESSAGE".to_string(), self.message.clone());
+        vars.insert("GOA_LAST_COMMIT_TIME".to_string(), self.time.clone());
+        vars
+    }
+}
 
 pub fn is_diff<'a>(
     repo: &'a git2::Repository,
@@ -101,14 +123,15 @@ pub fn is_diff<'a>(
     }
 }
 
-pub fn set_last_commit(
+/// Get commit metadata for the last commit on a branch.
+/// Returns CommitMetadata to be passed to child processes.
+pub fn get_last_commit_metadata(
     repo: &git2::Repository,
     branch_name: &str,
     verbosity: u8,
-) -> Result<(), git2::Error> {
+) -> Result<CommitMetadata, git2::Error> {
     let commit = find_last_commit_on_branch(repo, branch_name)?;
-    commit_to_envs(&commit, verbosity);
-    Ok(())
+    Ok(extract_commit_metadata(&commit, verbosity))
 }
 
 pub fn tree_to_treeish<'a>(
@@ -168,9 +191,12 @@ fn find_last_commit(repo: &Repository) -> Result<Commit<'_>, git2::Error> {
         .map_err(|_| git2::Error::from_str("Couldn't find commit"))
 }
 
-fn commit_to_envs(commit: &Commit, verbosity: u8) {
+/// Extract metadata from a commit. Prints commit info if verbosity > 0.
+/// Returns CommitMetadata instead of setting global env vars (thread-safe).
+fn extract_commit_metadata(commit: &Commit, verbosity: u8) -> CommitMetadata {
     let timestamp = commit.time().seconds();
     let tm = DateTime::from_timestamp(timestamp, 0).unwrap_or_else(Utc::now);
+
     if verbosity > 0 {
         let dt = Utc::now();
         println!(
@@ -182,13 +208,13 @@ fn commit_to_envs(commit: &Commit, verbosity: u8) {
             commit.message().unwrap_or("no commit message")
         );
     }
-    env::set_var("GOA_LAST_COMMIT_ID", commit.id().to_string());
-    env::set_var("GOA_LAST_COMMIT_AUTHOR", commit.author().to_string());
-    env::set_var(
-        "GOA_LAST_COMMIT_MESSAGE",
-        commit.message().unwrap_or(""),
-    );
-    env::set_var("GOA_LAST_COMMIT_TIME", tm.to_string());
+
+    CommitMetadata {
+        id: commit.id().to_string(),
+        author: commit.author().to_string(),
+        message: commit.message().unwrap_or("").to_string(),
+        time: tm.to_string(),
+    }
 }
 
 fn fast_forward(
@@ -250,12 +276,13 @@ fn normal_merge(
     Ok(())
 }
 
+/// Perform a merge and return the commit metadata for the resulting commit.
 pub fn do_merge<'a>(
     repo: &'a Repository,
     remote_branch: &str,
     fetch_commit: git2::AnnotatedCommit<'a>,
     verbosity: u8,
-) -> Result<(), git2::Error> {
+) -> Result<CommitMetadata, git2::Error> {
     // 1. do a merge analysis
     let analysis = repo.merge_analysis(&[&fetch_commit])?;
 
@@ -287,15 +314,15 @@ pub fn do_merge<'a>(
             }
         };
         let commit = find_last_commit(repo)?;
-        commit_to_envs(&commit, verbosity);
+        Ok(extract_commit_metadata(&commit, verbosity))
     } else if analysis.0.is_normal() {
         // do a normal merge
         let head_commit = repo.reference_to_annotated_commit(&repo.head()?)?;
         normal_merge(repo, &head_commit, &fetch_commit)?;
         let commit = find_last_commit(repo)?;
-        commit_to_envs(&commit, verbosity);
+        Ok(extract_commit_metadata(&commit, verbosity))
     } else {
         eprintln!("Error: Nothing to do?");
+        Ok(CommitMetadata::default())
     }
-    Ok(())
 }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -13,7 +13,7 @@ use clokwerk::{Scheduler, TimeUnits};
 
 use git2::Repository;
 
-use crate::git;
+use crate::git::{self, CommitMetadata};
 
 #[derive(Debug, Clone)]
 pub struct Repo {
@@ -153,9 +153,9 @@ pub fn do_process_once(repo: &mut Repo) -> Result<()> {
         Error::other(format!("goa error: failed to open the cloned repo: {}", e))
     })?;
 
-    git::set_last_commit(&local_repo, &repo.branch, repo.verbosity).map_err(|e| {
-        Error::other(format!("branch '{}' not found: {}", repo.branch, e))
-    })?;
+    // Get commit metadata (thread-safe, no global env var mutation)
+    let metadata = git::get_last_commit_metadata(&local_repo, &repo.branch, repo.verbosity)
+        .map_err(|e| Error::other(format!("branch '{}' not found: {}", repo.branch, e)))?;
 
     if repo.command.is_empty() {
         repo.command = read_goa_file(format!("{}/.goa", local_path));
@@ -164,7 +164,7 @@ pub fn do_process_once(repo: &mut Repo) -> Result<()> {
         }
     }
 
-    match do_task(repo) {
+    match do_task(repo, Some(&metadata)) {
         Ok(output) => {
             if repo.verbosity > 0 {
                 info!("command stdout: {}", output);
@@ -197,14 +197,14 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
     match git::is_diff(&local_repo, "origin", &repo.branch, repo.verbosity) {
         Ok(commit) => {
             match git::do_merge(&local_repo, &repo.branch, commit, repo.verbosity) {
-                Ok(()) => {
+                Ok(metadata) => {
                     if repo.command.is_empty() {
                         repo.command = read_goa_file(format!("{}/.goa", local_path));
                         if repo.verbosity > 2 {
                             debug!(".goa file command {}", repo.command);
                         }
                     }
-                    match do_task(repo) {
+                    match do_task(repo, Some(&metadata)) {
                         Ok(output) => {
                             if repo.verbosity > 0 {
                                 info!("command stdout: {}", output);
@@ -241,7 +241,9 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
     Ok(())
 }
 
-fn do_task(repo: &mut Repo) -> Result<String> {
+/// Execute a command with optional commit metadata passed as env vars to child process.
+/// This is thread-safe as env vars are only set in the child process, not globally.
+fn do_task(repo: &mut Repo, metadata: Option<&CommitMetadata>) -> Result<String> {
     let local_path = repo
         .local_path
         .as_ref()
@@ -255,6 +257,11 @@ fn do_task(repo: &mut Repo) -> Result<String> {
 
     let mut options = ScriptOptions::new();
     options.working_directory = Some(PathBuf::from(local_path));
+
+    // Pass commit metadata as env vars to child process only (thread-safe)
+    if let Some(meta) = metadata {
+        options.env_vars = Some(meta.to_env_vars());
+    }
 
     let args = vec![];
 
@@ -320,7 +327,7 @@ mod repos_tests {
             false,
         );
 
-        let res = do_task(&mut repo);
+        let res = do_task(&mut repo, None);
         assert_eq!(String::from("hello\n"), res.unwrap());
     }
 


### PR DESCRIPTION
## Summary
- Add `CommitMetadata` struct to encapsulate git commit information
- Replace global `env::set_var()` calls with child-process-only env vars via `run_script::ScriptOptions`
- Rename `set_last_commit` to `get_last_commit_metadata` (returns data instead of mutating globals)
- Update `do_merge` to return `CommitMetadata` for downstream use

## Test plan
- [x] All unit tests pass (`cargo test` - 6 tests)
- [x] All CLI integration tests pass (9 tests)
- [x] `cargo clippy` passes with no new warnings
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)