### PR TITLE
refactor: redesign Repo struct with builder pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,20 +29,26 @@ fn main() -> anyhow::Result<()> {
             target_path,
             timeout,
         } => {
-            let repo = Repo::new(
-                url,
-                username,
-                token,
-                Some(String::from("initialize")),
-                target_path,
-                branch,
-                command,
-                delay,
-                verbosity,
-                exec_on_start,
-                exit_on_first_diff,
-                timeout,
-            );
+            let mut builder = Repo::builder(&url)
+                .branch(branch)
+                .delay(delay)
+                .verbosity(verbosity)
+                .exec_on_start(exec_on_start)
+                .exit_on_first_diff(exit_on_first_diff)
+                .timeout(timeout)
+                .command(command);
+
+            if let Some(u) = username {
+                builder = builder.username(u);
+            }
+            if let Some(t) = token {
+                builder = builder.token(t);
+            }
+            if let Some(p) = target_path {
+                builder = builder.local_path(p);
+            }
+
+            let repo = builder.build();
 
             let log_level = match verbosity {
                 0 => "error",

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,5 +1,4 @@
 use std::io::{Error, Read as IoRead, Result};
-use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -17,56 +16,199 @@ use git2::Repository;
 
 use crate::git::{self, CommitMetadata};
 
+/// Repository configuration for monitoring a git repository.
+/// Use `RepoBuilder` to construct instances.
 #[derive(Debug, Clone)]
 pub struct Repo {
-    pub url: String,
-    pub username: Option<String>,
-    pub token: Option<String>,
-    #[allow(dead_code)] // TODO: Issue #11 - store run count and timestamps
-    pub status: Option<String>,
-    pub local_path: Option<String>,
-    pub branch: String,
-    pub command: String,
-    pub delay: u16,
-    pub verbosity: u8,
-    pub exec_on_start: bool,
-    pub exit_on_first_diff: bool,
-    pub timeout: u64,
+    url: String,
+    username: Option<String>,
+    token: Option<String>,
+    local_path: Option<String>,
+    branch: String,
+    command: Option<String>,
+    delay: u16,
+    verbosity: u8,
+    exec_on_start: bool,
+    exit_on_first_diff: bool,
+    timeout: u64,
 }
 
 impl Repo {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        url: String,
-        username: Option<String>,
-        token: Option<String>,
-        status: Option<String>,
-        local_path: Option<String>,
-        branch: String,
-        command: String,
-        delay: u16,
-        verbosity: u8,
-        exec_on_start: bool,
-        exit_on_first_diff: bool,
-        timeout: u64,
-    ) -> Repo {
-        // We'll initialize after the clone is successful.
-        Repo {
-            url,
-            username,
-            token,
-            status,
-            local_path,
-            branch,
-            command,
-            delay,
-            verbosity,
-            exec_on_start,
-            exit_on_first_diff,
-            timeout,
+    /// Create a new builder for constructing a Repo
+    pub fn builder(url: impl Into<String>) -> RepoBuilder {
+        RepoBuilder::new(url)
+    }
+
+    // Getters for all fields
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn set_url(&mut self, url: String) {
+        self.url = url;
+    }
+
+    pub fn username(&self) -> Option<&str> {
+        self.username.as_deref()
+    }
+
+    pub fn token(&self) -> Option<&str> {
+        self.token.as_deref()
+    }
+
+    pub fn local_path(&self) -> Option<&str> {
+        self.local_path.as_deref()
+    }
+
+    pub fn set_local_path(&mut self, path: String) {
+        self.local_path = Some(path);
+    }
+
+    pub fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    pub fn command(&self) -> Option<&str> {
+        self.command.as_deref()
+    }
+
+    pub fn delay(&self) -> u16 {
+        self.delay
+    }
+
+    pub fn verbosity(&self) -> u8 {
+        self.verbosity
+    }
+
+    pub fn exec_on_start(&self) -> bool {
+        self.exec_on_start
+    }
+
+    pub fn exit_on_first_diff(&self) -> bool {
+        self.exit_on_first_diff
+    }
+
+    pub fn timeout(&self) -> u64 {
+        self.timeout
+    }
+}
+
+/// Builder for constructing `Repo` instances with a fluent API.
+#[derive(Debug, Clone)]
+pub struct RepoBuilder {
+    url: String,
+    username: Option<String>,
+    token: Option<String>,
+    local_path: Option<String>,
+    branch: String,
+    command: Option<String>,
+    delay: u16,
+    verbosity: u8,
+    exec_on_start: bool,
+    exit_on_first_diff: bool,
+    timeout: u64,
+}
+
+impl RepoBuilder {
+    /// Create a new builder with the required URL
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            username: None,
+            token: None,
+            local_path: None,
+            branch: String::from("main"),
+            command: None,
+            delay: 120,
+            verbosity: 1,
+            exec_on_start: false,
+            exit_on_first_diff: false,
+            timeout: 0,
         }
     }
 
+    /// Set the username for authentication
+    pub fn username(mut self, username: impl Into<String>) -> Self {
+        let u = username.into();
+        self.username = if u.is_empty() { None } else { Some(u) };
+        self
+    }
+
+    /// Set the token for authentication
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        let t = token.into();
+        self.token = if t.is_empty() { None } else { Some(t) };
+        self
+    }
+
+    /// Set the local path for cloning
+    pub fn local_path(mut self, path: impl Into<String>) -> Self {
+        self.local_path = Some(path.into());
+        self
+    }
+
+    /// Set the branch to monitor (default: "main")
+    pub fn branch(mut self, branch: impl Into<String>) -> Self {
+        self.branch = branch.into();
+        self
+    }
+
+    /// Set the command to execute on changes (if not set, reads from .goa file)
+    pub fn command(mut self, command: impl Into<String>) -> Self {
+        let c = command.into();
+        self.command = if c.is_empty() { None } else { Some(c) };
+        self
+    }
+
+    /// Set the delay between checks in seconds (default: 120)
+    pub fn delay(mut self, delay: u16) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    /// Set the verbosity level (default: 1)
+    pub fn verbosity(mut self, verbosity: u8) -> Self {
+        self.verbosity = verbosity;
+        self
+    }
+
+    /// Execute command on startup (default: false)
+    pub fn exec_on_start(mut self, exec: bool) -> Self {
+        self.exec_on_start = exec;
+        self
+    }
+
+    /// Exit after first diff is processed (default: false)
+    pub fn exit_on_first_diff(mut self, exit: bool) -> Self {
+        self.exit_on_first_diff = exit;
+        self
+    }
+
+    /// Set command timeout in seconds (0 = no timeout, default: 0)
+    pub fn timeout(mut self, timeout: u64) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Build the Repo instance
+    pub fn build(self) -> Repo {
+        Repo {
+            url: self.url,
+            username: self.username,
+            token: self.token,
+            local_path: self.local_path,
+            branch: self.branch,
+            command: self.command,
+            delay: self.delay,
+            verbosity: self.verbosity,
+            exec_on_start: self.exec_on_start,
+            exit_on_first_diff: self.exit_on_first_diff,
+            timeout: self.timeout,
+        }
+    }
+}
+
+impl Repo {
     pub fn clone_repo(&self) -> Result<()> {
         let local_path = self
             .local_path
@@ -75,7 +217,7 @@ impl Repo {
 
         // Some OS-specific non-sense with trailing / in paths
         let local_target = str::replace(local_path, "//", "/");
-        match Repository::clone(self.url.as_str(), local_target) {
+        match Repository::clone(&self.url, local_target) {
             Ok(_repo) => {
                 if self.verbosity > 0 {
                     info!("cloned remote repo to {}", local_path);
@@ -100,10 +242,10 @@ impl Repo {
         let cloned_repo = Arc::new(Mutex::new(self.clone()));
 
         if self.exec_on_start {
-            let mut mut_repo = cloned_repo
+            let repo_guard = cloned_repo
                 .lock()
                 .map_err(|e| Error::other(format!("Failed to acquire lock: {}", e)))?;
-            match do_process_once(mut_repo.deref_mut()) {
+            match do_process_once(&repo_guard) {
                 Ok(()) => {
                     if self.verbosity > 0 {
                         info!("exec on startup complete");
@@ -119,8 +261,8 @@ impl Repo {
         // Add the repo to scheduler
         scheduler.every(delay.seconds()).run(move || {
             match cloned_repo.lock() {
-                Ok(mut mut_repo) => {
-                    if let Err(e) = do_process(mut_repo.deref_mut()) {
+                Ok(repo_guard) => {
+                    if let Err(e) = do_process(&repo_guard) {
                         eprintln!("goa error: unable to process repo: {}", e);
                     }
                 }
@@ -138,8 +280,8 @@ impl Repo {
     }
 }
 
-pub fn read_goa_file(goa_path: String) -> String {
-    if std::path::Path::new(&goa_path).exists() {
+pub fn read_goa_file(goa_path: &str) -> String {
+    if std::path::Path::new(goa_path).exists() {
         std::fs::read_to_string(goa_path).unwrap_or_else(|_| {
             String::from("echo 'failed to read .goa file'")
         })
@@ -148,10 +290,17 @@ pub fn read_goa_file(goa_path: String) -> String {
     }
 }
 
-pub fn do_process_once(repo: &mut Repo) -> Result<()> {
+/// Get the effective command to execute: use configured command or read from .goa file
+fn get_effective_command(repo: &Repo, local_path: &str) -> String {
+    match repo.command() {
+        Some(cmd) => cmd.to_string(),
+        None => read_goa_file(&format!("{}/.goa", local_path)),
+    }
+}
+
+pub fn do_process_once(repo: &Repo) -> Result<()> {
     let local_path = repo
-        .local_path
-        .as_ref()
+        .local_path()
         .ok_or_else(|| Error::other("local_path is not set"))?;
 
     let local_repo = Repository::open(local_path).map_err(|e| {
@@ -159,19 +308,18 @@ pub fn do_process_once(repo: &mut Repo) -> Result<()> {
     })?;
 
     // Get commit metadata (thread-safe, no global env var mutation)
-    let metadata = git::get_last_commit_metadata(&local_repo, &repo.branch, repo.verbosity)
-        .map_err(|e| Error::other(format!("branch '{}' not found: {}", repo.branch, e)))?;
+    let metadata = git::get_last_commit_metadata(&local_repo, repo.branch(), repo.verbosity())
+        .map_err(|e| Error::other(format!("branch '{}' not found: {}", repo.branch(), e)))?;
 
-    if repo.command.is_empty() {
-        repo.command = read_goa_file(format!("{}/.goa", local_path));
-        if repo.verbosity > 2 {
-            debug!(".goa file command {}", repo.command);
-        }
+    // Determine the effective command: use configured command or read from .goa file
+    let effective_command = get_effective_command(repo, local_path);
+    if repo.verbosity() > 2 {
+        debug!("effective command: {}", effective_command);
     }
 
-    match do_task(repo, Some(&metadata)) {
+    match do_task(repo, &effective_command, Some(&metadata)) {
         Ok(output) => {
-            if repo.verbosity > 0 {
+            if repo.verbosity() > 0 {
                 info!("command stdout: {}", output);
             } else {
                 println!("{output}");
@@ -184,40 +332,38 @@ pub fn do_process_once(repo: &mut Repo) -> Result<()> {
     Ok(())
 }
 
-pub fn do_process(repo: &mut Repo) -> Result<()> {
+pub fn do_process(repo: &Repo) -> Result<()> {
     let local_path = repo
-        .local_path
-        .as_ref()
-        .ok_or_else(|| Error::other("local_path is not set"))?
-        .clone();
+        .local_path()
+        .ok_or_else(|| Error::other("local_path is not set"))?;
 
-    let local_repo = Repository::open(&local_path).map_err(|e| {
+    let local_repo = Repository::open(local_path).map_err(|e| {
         Error::other(format!("goa error: failed to open the cloned repo: {}", e))
     })?;
 
-    if repo.verbosity > 1 {
-        info!("checking for diffs at origin/{}!", repo.branch);
+    if repo.verbosity() > 1 {
+        info!("checking for diffs at origin/{}!", repo.branch());
     }
 
-    match git::is_diff(&local_repo, "origin", &repo.branch, repo.verbosity) {
+    match git::is_diff(&local_repo, "origin", repo.branch(), repo.verbosity()) {
         Ok(commit) => {
-            match git::do_merge(&local_repo, &repo.branch, commit, repo.verbosity) {
+            match git::do_merge(&local_repo, repo.branch(), commit, repo.verbosity()) {
                 Ok(metadata) => {
-                    if repo.command.is_empty() {
-                        repo.command = read_goa_file(format!("{}/.goa", local_path));
-                        if repo.verbosity > 2 {
-                            debug!(".goa file command {}", repo.command);
-                        }
+                    // Determine the effective command: use configured command or read from .goa file
+                    let effective_command = get_effective_command(repo, local_path);
+                    if repo.verbosity() > 2 {
+                        debug!("effective command: {}", effective_command);
                     }
-                    match do_task(repo, Some(&metadata)) {
+
+                    match do_task(repo, &effective_command, Some(&metadata)) {
                         Ok(output) => {
-                            if repo.verbosity > 0 {
+                            if repo.verbosity() > 0 {
                                 info!("command stdout: {}", output);
                             } else {
                                 println!("{output}");
                             }
 
-                            if repo.exit_on_first_diff {
+                            if repo.exit_on_first_diff() {
                                 // Intentional exit after first diff processed
                                 std::process::exit(0);
                             }
@@ -226,9 +372,6 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
                             eprintln!("goa error: do_task error {}", e);
                         }
                     }
-
-                    // Reset the .goa file command
-                    repo.command = String::from("");
                 }
                 Err(e) => {
                     eprintln!("goa error: do_merge error {}", e);
@@ -237,7 +380,7 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
         }
         Err(e) => {
             // There were no diffs, so we move right along
-            if repo.verbosity > 1 {
+            if repo.verbosity() > 1 {
                 debug!("{}", e);
             }
         }
@@ -249,26 +392,25 @@ pub fn do_process(repo: &mut Repo) -> Result<()> {
 /// Execute a command with optional commit metadata passed as env vars to child process.
 /// This is thread-safe as env vars are only set in the child process, not globally.
 /// If timeout > 0, the command will be killed after the specified number of seconds.
-fn do_task(repo: &mut Repo, metadata: Option<&CommitMetadata>) -> Result<String> {
+fn do_task(repo: &Repo, command: &str, metadata: Option<&CommitMetadata>) -> Result<String> {
     let local_path = repo
-        .local_path
-        .as_ref()
+        .local_path()
         .ok_or_else(|| Error::other("local_path is not set"))?;
 
-    if repo.verbosity > 1 {
-        info!("running -> {}", repo.command);
-        if repo.timeout > 0 {
-            info!("timeout -> {} seconds", repo.timeout);
+    if repo.verbosity() > 1 {
+        info!("running -> {}", command);
+        if repo.timeout() > 0 {
+            info!("timeout -> {} seconds", repo.timeout());
         }
     }
 
-    if repo.verbosity > 2 {
+    if repo.verbosity() > 2 {
         debug!("path -> {}", local_path);
     }
 
     // Use timeout-based execution if timeout is set
-    if repo.timeout > 0 {
-        return do_task_with_timeout(repo, metadata, local_path);
+    if repo.timeout() > 0 {
+        return do_task_with_timeout(repo, command, metadata, local_path);
     }
 
     // No timeout - use run_script for simpler execution
@@ -283,10 +425,10 @@ fn do_task(repo: &mut Repo, metadata: Option<&CommitMetadata>) -> Result<String>
     let args = vec![];
 
     // run the script and get the script execution output
-    let (code, output, error) = run_script::run(&repo.command, &args, &options)
+    let (code, output, error) = run_script::run(command, &args, &options)
         .map_err(|e| Error::other(format!("Failed to run script: {}", e)))?;
 
-    if repo.verbosity > 1 {
+    if repo.verbosity() > 1 {
         info!("command status: {}", code);
         info!("command stderr:\n{}", error);
     }
@@ -303,15 +445,16 @@ fn do_task(repo: &mut Repo, metadata: Option<&CommitMetadata>) -> Result<String>
 /// Execute a command with a timeout. Kills the process if it exceeds the timeout.
 fn do_task_with_timeout(
     repo: &Repo,
+    command: &str,
     metadata: Option<&CommitMetadata>,
     local_path: &str,
 ) -> Result<String> {
-    let timeout_duration = Duration::from_secs(repo.timeout);
+    let timeout_duration = Duration::from_secs(repo.timeout());
 
     // Build the command using sh -c for shell interpretation
     let mut cmd = Command::new("sh");
     cmd.arg("-c")
-        .arg(&repo.command)
+        .arg(command)
         .current_dir(local_path)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -345,7 +488,7 @@ fn do_task_with_timeout(
 
             let code = status.code().unwrap_or(-1);
 
-            if repo.verbosity > 1 {
+            if repo.verbosity() > 1 {
                 info!("command status: {}", code);
                 info!("command stderr:\n{}", stderr);
             }
@@ -360,10 +503,10 @@ fn do_task_with_timeout(
         }
         Ok(None) => {
             // Timeout expired - kill the process
-            if repo.verbosity > 0 {
+            if repo.verbosity() > 0 {
                 warn!(
                     "Command timed out after {} seconds, killing process",
-                    repo.timeout
+                    repo.timeout()
                 );
             }
             child
@@ -373,7 +516,7 @@ fn do_task_with_timeout(
 
             Err(Error::other(format!(
                 "Command timed out after {} seconds",
-                repo.timeout
+                repo.timeout()
             )))
         }
         Err(e) => Err(Error::other(format!("Failed to wait on command: {}", e))),
@@ -387,42 +530,36 @@ mod repos_tests {
 
     #[test]
     fn test_creation_of_repo() {
-        let repo = Repo::new(
-            String::from("file://."),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(".")),
-            String::from("develop"),
-            String::from(""),
-            120,
-            1,
-            false,
-            false,
-            0,
-        );
+        let repo = Repo::builder("file://.")
+            .local_path(".")
+            .branch("develop")
+            .build();
 
-        assert_eq!("develop", repo.branch);
+        assert_eq!("develop", repo.branch());
+    }
+
+    #[test]
+    fn test_builder_defaults() {
+        let repo = Repo::builder("https://github.com/test/repo").build();
+
+        assert_eq!("main", repo.branch());
+        assert_eq!(120, repo.delay());
+        assert_eq!(1, repo.verbosity());
+        assert!(!repo.exec_on_start());
+        assert!(!repo.exit_on_first_diff());
+        assert_eq!(0, repo.timeout());
     }
 
     #[test]
     fn test_do_task() {
-        let mut repo = Repo::new(
-            String::from("file://."),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(".")),
-            String::from("develop"),
-            String::from("echo hello"),
-            120,
-            3,
-            false,
-            false,
-            0,
-        );
+        let repo = Repo::builder("file://.")
+            .local_path(".")
+            .branch("develop")
+            .command("echo hello")
+            .verbosity(3)
+            .build();
 
-        let res = do_task(&mut repo, None);
+        let res = do_task(&repo, "echo hello", None);
         assert_eq!(String::from("hello\n"), res.unwrap());
     }
 
@@ -432,24 +569,17 @@ mod repos_tests {
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
         let tmp_dir_name = format!("/{}/", uuid::Uuid::new_v4());
         local_path.push_str(&tmp_dir_name);
-        let mut repo = Repo::new(
-            String::from("https://github.com/kitplummer/goa_tester"),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(local_path)),
-            String::from("main"),
-            String::from("echo hello"),
-            120,
-            2,
-            false,
-            false,
-            0,
-        );
+
+        let repo = Repo::builder("https://github.com/kitplummer/goa_tester")
+            .local_path(&local_path)
+            .branch("main")
+            .command("echo hello")
+            .verbosity(2)
+            .build();
 
         repo.clone_repo()?;
 
-        assert_eq!(do_process(&mut repo)?, ());
+        assert_eq!(do_process(&repo)?, ());
         Ok(())
     }
 
@@ -459,24 +589,17 @@ mod repos_tests {
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
         let tmp_dir_name = format!("/{}/", uuid::Uuid::new_v4());
         local_path.push_str(&tmp_dir_name);
-        let mut repo = Repo::new(
-            String::from("https://github.com/kitplummer/goa_tester"),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(local_path)),
-            String::from("main"),
-            String::from("echo hello"),
-            120,
-            2,
-            false,
-            false,
-            0,
-        );
+
+        let mut repo = Repo::builder("https://github.com/kitplummer/goa_tester")
+            .local_path(&local_path)
+            .branch("main")
+            .command("echo hello")
+            .verbosity(2)
+            .build();
 
         repo.clone_repo()?;
-        repo.local_path = Some(String::from("/blahdyblahblah"));
-        let res = do_process(&mut repo).unwrap_err();
+        repo.set_local_path(String::from("/blahdyblahblah"));
+        let res = do_process(&repo).unwrap_err();
         assert_eq!(res.kind(), ErrorKind::Other);
 
         Ok(())
@@ -489,72 +612,50 @@ mod repos_tests {
         let tmp_dir_name = format!("/{}/", uuid::Uuid::new_v4());
         local_path.push_str(&tmp_dir_name);
         println!("local_path: {:?}", local_path);
-        let mut repo = Repo::new(
-            String::from("https://github.com/kitplummer/goa_tester"),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(local_path)),
-            String::from("main"),
-            String::from(""),
-            120,
-            3,
-            false,
-            false,
-            0,
-        );
+
+        let repo = Repo::builder("https://github.com/kitplummer/goa_tester")
+            .local_path(&local_path)
+            .branch("main")
+            .verbosity(3)
+            .build();
 
         repo.clone_repo()?;
 
-        assert_eq!(do_process(&mut repo)?, ());
+        assert_eq!(do_process(&repo)?, ());
         Ok(())
     }
 
     #[test]
     fn test_no_goa_file() {
-        let res = read_goa_file(String::from("/blahdy/.goa"));
+        let res = read_goa_file("/blahdy/.goa");
         assert_eq!(res, String::from("echo 'no goa file found yet'"));
     }
 
     #[test]
     fn test_do_task_with_timeout() {
-        let mut repo = Repo::new(
-            String::from("file://."),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(".")),
-            String::from("develop"),
-            String::from("echo hello"),
-            120,
-            3,
-            false,
-            false,
-            5, // 5 second timeout
-        );
+        let repo = Repo::builder("file://.")
+            .local_path(".")
+            .branch("develop")
+            .command("echo hello")
+            .verbosity(3)
+            .timeout(5)
+            .build();
 
-        let res = do_task(&mut repo, None);
+        let res = do_task(&repo, "echo hello", None);
         assert_eq!(String::from("hello\n"), res.unwrap());
     }
 
     #[test]
     fn test_do_task_timeout_exceeded() {
-        let mut repo = Repo::new(
-            String::from("file://."),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from("")),
-            Some(String::from(".")),
-            String::from("develop"),
-            String::from("sleep 10"),
-            120,
-            1,
-            false,
-            false,
-            1, // 1 second timeout - should fail
-        );
+        let repo = Repo::builder("file://.")
+            .local_path(".")
+            .branch("develop")
+            .command("sleep 10")
+            .verbosity(1)
+            .timeout(1)
+            .build();
 
-        let res = do_task(&mut repo, None);
+        let res = do_task(&repo, "sleep 10", None);
         assert!(res.is_err());
         assert!(res.unwrap_err().to_string().contains("timed out"));
     }

--- a/src/spy/mod.rs
+++ b/src/spy/mod.rs
@@ -7,19 +7,20 @@ use uuid::Uuid;
 use crate::repos::Repo;
 
 pub fn spy_repo(mut repo: Repo) -> Result<()> {
-    if repo.verbosity > 0 {
-        info!("starting to spy {}:{}", repo.url, repo.branch);
+    if repo.verbosity() > 0 {
+        info!("starting to spy {}:{}", repo.url(), repo.branch());
     }
 
-    repo.url = match Url::parse(&repo.url) {
+    // Parse and potentially modify URL with credentials
+    let authenticated_url = match Url::parse(repo.url()) {
         Ok(mut parsed_url) => {
-            if let Some(ref username) = repo.username {
+            if let Some(username) = repo.username() {
                 parsed_url
                     .set_username(username)
                     .map_err(|_| Error::other("Failed to set username in URL"))?;
             }
 
-            if let Some(ref token) = repo.token {
+            if let Some(token) = repo.token() {
                 parsed_url
                     .set_password(Some(token))
                     .map_err(|_| Error::other("Failed to set password in URL"))?;
@@ -30,8 +31,9 @@ pub fn spy_repo(mut repo: Repo) -> Result<()> {
             return Err(Error::other(format!("goa error: invalid URL or path, {}", e)));
         }
     };
+    repo.set_url(authenticated_url);
 
-    if repo.local_path.is_none() {
+    if repo.local_path().is_none() {
         // Get a temp directory to do work in
         let temp = temp_dir();
         let local_path = temp
@@ -41,7 +43,7 @@ pub fn spy_repo(mut repo: Repo) -> Result<()> {
         let tmp_dir_name = format!("{}/{}/", local_path, Uuid::new_v4());
 
         // Set the local repo path in the repo struct
-        repo.local_path = Some(tmp_dir_name);
+        repo.set_local_path(tmp_dir_name);
     }
 
     // Clone the repo and set the local path


### PR DESCRIPTION
## Summary
- Replace 12-argument constructor with fluent `RepoBuilder` API
- Make `Repo` fields private with getter methods
- Change `command` field to `Option<String>` (None = read from .goa file)
- Pass effective command to `do_task` instead of mutating the repo struct
- Add sensible defaults (branch: "main", delay: 120s, verbosity: 1, etc.)

## Example Usage
```rust
// Before (hard to read, easy to mix up args)
let repo = Repo::new(url, username, token, status, local_path, branch, command, delay, verbosity, exec_on_start, exit_on_first_diff, timeout);

// After (clear and fluent)
let repo = Repo::builder("https://github.com/user/repo")
    .branch("develop")
    .command("make test")
    .timeout(30)
    .build();
```

## Test plan
- [x] All unit tests pass (9 tests including new builder defaults test)
- [x] All CLI integration tests pass (9 tests)
- [x] `cargo clippy` passes (only unused getter warnings - expected for public API)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)