### PR TITLE
feat: add Radicle HTTP API support for decentralized git CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ uuid = { version = "1", features = ["serde", "v4"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
 run_script = "0.11"
 wait-timeout = "0.2"
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
-    spy     Spy a remote git repo for changes, will continuously execute defined script/command on a diff
+    help      Prints this message or the help of the given subcommand(s)
+    spy       Spy a remote git repo for changes, will continuously execute defined script/command on a diff
+    radicle   Watch a Radicle repository for changes via HTTP API
 ```
 
 #### Version (--version)
@@ -85,6 +86,73 @@ This will output "changed!" on stdout then exit after the first diff is identifi
 * `goa -c 'echo "changed!" -T "/tmp/goa" -x https://github.com/kitplummer/goa_tester`
 
 Will do the same as above, but create the local clone at `/tmp/goa`.
+
+#### Radicle
+
+Watch a [Radicle](https://radicle.xyz) repository for changes via HTTP API. This enables CI/CD for decentralized git projects.
+
+```
+Watch a Radicle repository for changes via HTTP API
+
+Usage: goa radicle [OPTIONS] --seed-url <SEED_URL> --rid <RID>
+
+Options:
+  -s, --seed-url <SEED_URL>      The Radicle seed node URL (e.g., https://iris.radicle.xyz)
+  -r, --rid <RID>                The Radicle repository ID (e.g., rad:z3fF7wV6LXz915ND1nbHTfeY3Qcq7)
+  -c, --command <COMMAND>        The command to run when a change is detected [default: ]
+  -d, --delay <DELAY>            The time between checks in seconds, max 65535 [default: 120]
+  -v, --verbosity <VERBOSITY>    Adjust level of stdout, 0 no goa output, max 2 (debug) [default: 1]
+      --timeout <TIMEOUT>        Timeout for command execution in seconds (0 = no timeout) [default: 0]
+  -p, --watch-patches            Watch for patch (PR) updates in addition to head changes
+  -l, --local-path <LOCAL_PATH>  Local working directory for command execution and .goa file
+```
+
+##### Radicle Examples
+
+* Watch for pushes and patches on a Radicle repo:
+```bash
+goa radicle -s https://iris.radicle.xyz -r rad:z3fF7wV6LXz915ND1nbHTfeY3Qcq7 -c './run-ci.sh'
+```
+
+* Watch only for head changes (no patches):
+```bash
+goa radicle -s https://iris.radicle.xyz -r rad:z3fF7wV6LXz915ND1nbHTfeY3Qcq7 -c 'echo "new push!"' --watch-patches=false
+```
+
+##### Radicle Environment Variables
+
+When triggered by Radicle events, goa provides these environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `GOA_RADICLE_RID` | Repository ID (e.g., `rad:z3fF7wV6LXz915ND1nbHTfeY3Qcq7`) |
+| `GOA_RADICLE_URL` | Seed node URL |
+| `GOA_TRIGGER_TYPE` | `push` or `patch` |
+| `GOA_COMMIT_OID` | Commit SHA to test |
+| `GOA_PATCH_ID` | Patch ID (if trigger_type=patch) |
+| `GOA_BASE_COMMIT` | Base commit for patches |
+| `GOA_PATCH_STATE` | Patch state: open/merged/archived |
+| `GOA_PATCH_TITLE` | Patch title |
+
+##### Example CI Script for Radicle
+
+```bash
+#!/bin/bash
+echo "Testing commit $GOA_COMMIT_OID"
+if [ "$GOA_TRIGGER_TYPE" = "patch" ]; then
+  echo "Patch: $GOA_PATCH_ID - $GOA_PATCH_TITLE"
+  echo "Base: $GOA_BASE_COMMIT"
+fi
+
+# Clone from local Radicle storage and checkout the commit
+git clone ~/.radicle/storage/${GOA_RADICLE_RID#rad:} /tmp/ci-$$
+cd /tmp/ci-$$
+git checkout $GOA_COMMIT_OID
+
+# Run tests
+cargo test
+```
+
 ### Using a `.goa` File
 
 If no `-c`/`--command` is provided when starting `goa` - it will automatically look for a `.goa` file in the remote git repository, and execute the command within it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,34 @@ pub enum Action {
         #[arg(long, default_value = "0")]
         timeout: u64,
     },
+
+    /// Watch a Radicle repository for changes via HTTP API
+    Radicle {
+        /// The Radicle seed node URL (e.g., https://iris.radicle.xyz)
+        #[arg(short = 's', long)]
+        seed_url: String,
+        /// The Radicle repository ID (e.g., rad:z3fF7wV6LXz915ND1nbHTfeY3Qcq7)
+        #[arg(short, long)]
+        rid: String,
+        /// The command to run when a change is detected
+        #[arg(short, long, default_value = "")]
+        command: String,
+        /// The time between checks in seconds, max 65535
+        #[arg(short, long, default_value = "120")]
+        delay: u16,
+        /// Adjust level of stdout, 0 no goa output, max 2 (debug)
+        #[arg(short, long, default_value = "1")]
+        verbosity: u8,
+        /// Timeout for command execution in seconds (0 = no timeout)
+        #[arg(long, default_value = "0")]
+        timeout: u64,
+        /// Watch for patch (PR) updates in addition to head changes
+        #[arg(short = 'p', long, default_value = "true")]
+        watch_patches: bool,
+        /// Local working directory for command execution and .goa file
+        #[arg(short = 'l', long)]
+        local_path: Option<String>,
+    },
 }
 
 #[derive(Debug, Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 mod cli;
 mod git;
+mod radicle;
 mod repos;
 mod spy;
 
+use crate::radicle::RadicleConfig;
 use crate::repos::Repo;
 use clap::Parser;
 use cli::{Action::*, CommandLineArgs};
@@ -50,21 +52,53 @@ fn main() -> anyhow::Result<()> {
 
             let repo = builder.build();
 
-            let log_level = match verbosity {
-                0 => "error",
-                1 => "info",
-                _ => "debug",
-            };
-
-            Builder::from_env(Env::default().default_filter_or(log_level))
-                .target(Target::Stdout)
-                .init();
-
+            init_logger(verbosity);
             info!("starting");
 
             spy::spy_repo(repo)
         }
+
+        Radicle {
+            seed_url,
+            rid,
+            command,
+            delay,
+            verbosity,
+            timeout,
+            watch_patches,
+            local_path,
+        } => {
+            let mut builder = RadicleConfig::builder(&seed_url, &rid)
+                .delay(delay)
+                .verbosity(verbosity)
+                .timeout(timeout)
+                .watch_patches(watch_patches)
+                .command(command);
+
+            if let Some(path) = local_path {
+                builder = builder.local_path(path);
+            }
+
+            let config = builder.build();
+
+            init_logger(verbosity);
+            info!("starting radicle watcher");
+
+            radicle::watch_radicle(config)
+        }
     }?;
 
     Ok(())
+}
+
+fn init_logger(verbosity: u8) {
+    let log_level = match verbosity {
+        0 => "error",
+        1 => "info",
+        _ => "debug",
+    };
+
+    Builder::from_env(Env::default().default_filter_or(log_level))
+        .target(Target::Stdout)
+        .init();
 }

--- a/src/radicle/mod.rs
+++ b/src/radicle/mod.rs
@@ -1,0 +1,530 @@
+use std::collections::HashMap;
+use std::io::{Error, Result};
+use std::thread;
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde::Deserialize;
+
+use clokwerk::{Scheduler, TimeUnits};
+
+use crate::repos::{execute_command, read_goa_file};
+
+/// Radicle repository configuration
+#[derive(Debug, Clone)]
+pub struct RadicleConfig {
+    seed_url: String,
+    rid: String,
+    command: Option<String>,
+    delay: u16,
+    verbosity: u8,
+    timeout: u64,
+    watch_patches: bool,
+    local_path: Option<String>,
+}
+
+impl RadicleConfig {
+    pub fn builder(seed_url: impl Into<String>, rid: impl Into<String>) -> RadicleConfigBuilder {
+        RadicleConfigBuilder::new(seed_url, rid)
+    }
+
+    pub fn seed_url(&self) -> &str {
+        &self.seed_url
+    }
+
+    pub fn rid(&self) -> &str {
+        &self.rid
+    }
+
+    pub fn command(&self) -> Option<&str> {
+        self.command.as_deref()
+    }
+
+    pub fn delay(&self) -> u16 {
+        self.delay
+    }
+
+    pub fn verbosity(&self) -> u8 {
+        self.verbosity
+    }
+
+    pub fn timeout(&self) -> u64 {
+        self.timeout
+    }
+
+    pub fn watch_patches(&self) -> bool {
+        self.watch_patches
+    }
+
+    pub fn local_path(&self) -> Option<&str> {
+        self.local_path.as_deref()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RadicleConfigBuilder {
+    seed_url: String,
+    rid: String,
+    command: Option<String>,
+    delay: u16,
+    verbosity: u8,
+    timeout: u64,
+    watch_patches: bool,
+    local_path: Option<String>,
+}
+
+impl RadicleConfigBuilder {
+    pub fn new(seed_url: impl Into<String>, rid: impl Into<String>) -> Self {
+        Self {
+            seed_url: seed_url.into(),
+            rid: rid.into(),
+            command: None,
+            delay: 120,
+            verbosity: 1,
+            timeout: 0,
+            watch_patches: true,
+            local_path: None,
+        }
+    }
+
+    pub fn command(mut self, command: impl Into<String>) -> Self {
+        let c = command.into();
+        self.command = if c.is_empty() { None } else { Some(c) };
+        self
+    }
+
+    pub fn delay(mut self, delay: u16) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    pub fn verbosity(mut self, verbosity: u8) -> Self {
+        self.verbosity = verbosity;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: u64) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn watch_patches(mut self, watch: bool) -> Self {
+        self.watch_patches = watch;
+        self
+    }
+
+    pub fn local_path(mut self, path: impl Into<String>) -> Self {
+        self.local_path = Some(path.into());
+        self
+    }
+
+    pub fn build(self) -> RadicleConfig {
+        RadicleConfig {
+            seed_url: self.seed_url,
+            rid: self.rid,
+            command: self.command,
+            delay: self.delay,
+            verbosity: self.verbosity,
+            timeout: self.timeout,
+            watch_patches: self.watch_patches,
+            local_path: self.local_path,
+        }
+    }
+}
+
+/// Metadata for Radicle triggers, passed as env vars to commands
+#[derive(Debug, Clone, Default)]
+pub struct RadicleMetadata {
+    pub rid: String,
+    pub seed_url: String,
+    pub trigger_type: String, // "push" or "patch"
+    pub commit_oid: String,
+    pub patch_id: Option<String>,
+    pub base_commit: Option<String>,
+    pub patch_state: Option<String>,
+    pub patch_title: Option<String>,
+}
+
+impl RadicleMetadata {
+    pub fn to_env_vars(&self) -> HashMap<String, String> {
+        let mut vars = HashMap::new();
+        vars.insert("GOA_RADICLE_RID".to_string(), self.rid.clone());
+        vars.insert("GOA_RADICLE_URL".to_string(), self.seed_url.clone());
+        vars.insert("GOA_TRIGGER_TYPE".to_string(), self.trigger_type.clone());
+        vars.insert("GOA_COMMIT_OID".to_string(), self.commit_oid.clone());
+
+        if let Some(ref patch_id) = self.patch_id {
+            vars.insert("GOA_PATCH_ID".to_string(), patch_id.clone());
+        }
+        if let Some(ref base) = self.base_commit {
+            vars.insert("GOA_BASE_COMMIT".to_string(), base.clone());
+        }
+        if let Some(ref state) = self.patch_state {
+            vars.insert("GOA_PATCH_STATE".to_string(), state.clone());
+        }
+        if let Some(ref title) = self.patch_title {
+            vars.insert("GOA_PATCH_TITLE".to_string(), title.clone());
+        }
+
+        vars
+    }
+}
+
+// API Response types - fields kept for API completeness even if not all are used
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct RepoResponse {
+    pub rid: String,
+    pub payloads: Payloads,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Payloads {
+    #[serde(rename = "xyz.radicle.project")]
+    pub project: ProjectPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct ProjectPayload {
+    pub data: ProjectData,
+    pub meta: ProjectMeta,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct ProjectData {
+    pub name: String,
+    pub description: String,
+    pub default_branch: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProjectMeta {
+    pub head: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Patch {
+    pub id: String,
+    pub title: String,
+    pub state: PatchState,
+    pub revisions: Vec<Revision>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchState {
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Revision {
+    pub id: String,
+    pub oid: String,
+    pub base: String,
+    pub timestamp: i64,
+}
+
+/// State tracking for detecting changes
+#[derive(Debug, Clone, Default)]
+struct WatchState {
+    last_head: Option<String>,
+    last_patch_timestamps: HashMap<String, i64>,
+}
+
+/// Watch a Radicle repository for changes
+pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
+    if config.verbosity() > 0 {
+        info!(
+            "watching Radicle repo {} at {} every {} seconds",
+            config.rid(),
+            config.seed_url(),
+            config.delay()
+        );
+        if config.watch_patches() {
+            info!("also watching for patch updates");
+        }
+    }
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| Error::other(format!("Failed to create HTTP client: {}", e)))?;
+
+    let mut state = WatchState::default();
+
+    // Do initial fetch to establish baseline
+    if let Ok(repo_info) = fetch_repo_info(&client, &config) {
+        state.last_head = Some(repo_info.payloads.project.meta.head.clone());
+        if config.verbosity() > 0 {
+            info!("initial head: {}", repo_info.payloads.project.meta.head);
+        }
+    }
+
+    if config.watch_patches() {
+        if let Ok(patches) = fetch_patches(&client, &config) {
+            for patch in patches {
+                if let Some(rev) = patch.revisions.first() {
+                    state.last_patch_timestamps.insert(patch.id.clone(), rev.timestamp);
+                }
+            }
+            if config.verbosity() > 0 {
+                info!("tracking {} patches", state.last_patch_timestamps.len());
+            }
+        }
+    }
+
+    // Set up scheduler
+    let mut scheduler = Scheduler::new();
+    let delay = config.delay() as u32;
+
+    scheduler.every(delay.seconds()).run(move || {
+        if let Err(e) = check_for_changes(&client, &config, &mut state) {
+            eprintln!("goa error: failed to check Radicle repo: {}", e);
+        }
+    });
+
+    // Event loop
+    loop {
+        scheduler.run_pending();
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn fetch_repo_info(client: &Client, config: &RadicleConfig) -> Result<RepoResponse> {
+    let url = format!("{}/api/v1/repos/{}", config.seed_url(), config.rid());
+
+    if config.verbosity() > 1 {
+        debug!("fetching repo info from {}", url);
+    }
+
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|e| Error::other(format!("HTTP request failed: {}", e)))?;
+
+    if !response.status().is_success() {
+        return Err(Error::other(format!(
+            "API returned status {}",
+            response.status()
+        )));
+    }
+
+    response
+        .json::<RepoResponse>()
+        .map_err(|e| Error::other(format!("Failed to parse repo response: {}", e)))
+}
+
+fn fetch_patches(client: &Client, config: &RadicleConfig) -> Result<Vec<Patch>> {
+    let url = format!(
+        "{}/api/v1/repos/{}/patches",
+        config.seed_url(),
+        config.rid()
+    );
+
+    if config.verbosity() > 1 {
+        debug!("fetching patches from {}", url);
+    }
+
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|e| Error::other(format!("HTTP request failed: {}", e)))?;
+
+    if !response.status().is_success() {
+        return Err(Error::other(format!(
+            "API returned status {}",
+            response.status()
+        )));
+    }
+
+    response
+        .json::<Vec<Patch>>()
+        .map_err(|e| Error::other(format!("Failed to parse patches response: {}", e)))
+}
+
+fn check_for_changes(
+    client: &Client,
+    config: &RadicleConfig,
+    state: &mut WatchState,
+) -> Result<()> {
+    if config.verbosity() > 1 {
+        info!("checking for changes...");
+    }
+
+    // Check for head changes (push to main branch)
+    if let Ok(repo_info) = fetch_repo_info(client, config) {
+        let current_head = &repo_info.payloads.project.meta.head;
+
+        if let Some(ref last_head) = state.last_head {
+            if current_head != last_head {
+                if config.verbosity() > 0 {
+                    info!("detected push: {} -> {}", last_head, current_head);
+                }
+
+                let metadata = RadicleMetadata {
+                    rid: config.rid().to_string(),
+                    seed_url: config.seed_url().to_string(),
+                    trigger_type: "push".to_string(),
+                    commit_oid: current_head.clone(),
+                    ..Default::default()
+                };
+
+                execute_radicle_command(config, &metadata)?;
+                state.last_head = Some(current_head.clone());
+            }
+        } else {
+            state.last_head = Some(current_head.clone());
+        }
+    }
+
+    // Check for patch changes
+    if config.watch_patches() {
+        if let Ok(patches) = fetch_patches(client, config) {
+            for patch in patches {
+                // Only process open patches
+                if patch.state.status != "open" {
+                    continue;
+                }
+
+                if let Some(rev) = patch.revisions.first() {
+                    let last_timestamp = state.last_patch_timestamps.get(&patch.id).copied();
+
+                    let is_new_or_updated = match last_timestamp {
+                        Some(ts) => rev.timestamp > ts,
+                        None => true,
+                    };
+
+                    if is_new_or_updated {
+                        if config.verbosity() > 0 {
+                            info!(
+                                "detected patch update: {} - {}",
+                                &patch.id[..8],
+                                patch.title
+                            );
+                        }
+
+                        let metadata = RadicleMetadata {
+                            rid: config.rid().to_string(),
+                            seed_url: config.seed_url().to_string(),
+                            trigger_type: "patch".to_string(),
+                            commit_oid: rev.oid.clone(),
+                            patch_id: Some(patch.id.clone()),
+                            base_commit: Some(rev.base.clone()),
+                            patch_state: Some(patch.state.status.clone()),
+                            patch_title: Some(patch.title.clone()),
+                        };
+
+                        execute_radicle_command(config, &metadata)?;
+                        state.last_patch_timestamps.insert(patch.id.clone(), rev.timestamp);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_radicle_command(config: &RadicleConfig, metadata: &RadicleMetadata) -> Result<()> {
+    let effective_command = match config.command() {
+        Some(cmd) => cmd.to_string(),
+        None => {
+            // Try to read from local .goa file if local_path is set
+            match config.local_path() {
+                Some(path) => read_goa_file(&format!("{}/.goa", path)),
+                None => {
+                    return Err(Error::other(
+                        "No command specified and no local path for .goa file",
+                    ))
+                }
+            }
+        }
+    };
+
+    if config.verbosity() > 1 {
+        info!("executing: {}", effective_command);
+    }
+
+    let working_dir = config.local_path().unwrap_or(".");
+
+    match execute_command(
+        &effective_command,
+        working_dir,
+        Some(metadata.to_env_vars()),
+        config.timeout(),
+        config.verbosity(),
+    ) {
+        Ok(output) => {
+            if config.verbosity() > 0 {
+                info!("command stdout: {}", output);
+            } else {
+                println!("{}", output);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("goa error: command failed: {}", e);
+            Ok(()) // Don't stop watching on command failure
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_radicle_config_builder() {
+        let config = RadicleConfig::builder("https://iris.radicle.xyz", "rad:z123")
+            .command("echo test")
+            .delay(60)
+            .verbosity(2)
+            .timeout(30)
+            .watch_patches(false)
+            .build();
+
+        assert_eq!(config.seed_url(), "https://iris.radicle.xyz");
+        assert_eq!(config.rid(), "rad:z123");
+        assert_eq!(config.command(), Some("echo test"));
+        assert_eq!(config.delay(), 60);
+        assert_eq!(config.verbosity(), 2);
+        assert_eq!(config.timeout(), 30);
+        assert!(!config.watch_patches());
+    }
+
+    #[test]
+    fn test_radicle_metadata_env_vars() {
+        let metadata = RadicleMetadata {
+            rid: "rad:z123".to_string(),
+            seed_url: "https://iris.radicle.xyz".to_string(),
+            trigger_type: "patch".to_string(),
+            commit_oid: "abc123".to_string(),
+            patch_id: Some("patch456".to_string()),
+            base_commit: Some("def789".to_string()),
+            patch_state: Some("open".to_string()),
+            patch_title: Some("Fix bug".to_string()),
+        };
+
+        let vars = metadata.to_env_vars();
+        assert_eq!(vars.get("GOA_RADICLE_RID"), Some(&"rad:z123".to_string()));
+        assert_eq!(vars.get("GOA_TRIGGER_TYPE"), Some(&"patch".to_string()));
+        assert_eq!(vars.get("GOA_COMMIT_OID"), Some(&"abc123".to_string()));
+        assert_eq!(vars.get("GOA_PATCH_ID"), Some(&"patch456".to_string()));
+        assert_eq!(vars.get("GOA_BASE_COMMIT"), Some(&"def789".to_string()));
+    }
+
+    #[test]
+    fn test_radicle_config_defaults() {
+        let config = RadicleConfig::builder("https://example.com", "rad:test").build();
+
+        assert_eq!(config.delay(), 120);
+        assert_eq!(config.verbosity(), 1);
+        assert_eq!(config.timeout(), 0);
+        assert!(config.watch_patches());
+        assert!(config.command().is_none());
+    }
+}

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io::{Error, Read as IoRead, Result};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -287,6 +288,127 @@ pub fn read_goa_file(goa_path: &str) -> String {
         })
     } else {
         String::from("echo 'no goa file found yet'")
+    }
+}
+
+/// Execute a command with optional environment variables.
+/// This is a public function for use by other modules (e.g., radicle).
+pub fn execute_command(
+    command: &str,
+    working_dir: &str,
+    env_vars: Option<HashMap<String, String>>,
+    timeout: u64,
+    verbosity: u8,
+) -> Result<String> {
+    if verbosity > 1 {
+        info!("running -> {}", command);
+        if timeout > 0 {
+            info!("timeout -> {} seconds", timeout);
+        }
+    }
+
+    if verbosity > 2 {
+        debug!("path -> {}", working_dir);
+    }
+
+    // Use timeout-based execution if timeout is set
+    if timeout > 0 {
+        return execute_command_with_timeout(command, working_dir, env_vars, timeout, verbosity);
+    }
+
+    // No timeout - use run_script for simpler execution
+    let mut options = ScriptOptions::new();
+    options.working_directory = Some(PathBuf::from(working_dir));
+    options.env_vars = env_vars;
+
+    let args = vec![];
+
+    let (code, output, error) = run_script::run(command, &args, &options)
+        .map_err(|e| Error::other(format!("Failed to run script: {}", e)))?;
+
+    if verbosity > 1 {
+        info!("command status: {}", code);
+        info!("command stderr:\n{}", error);
+    }
+
+    if !error.is_empty() {
+        eprintln!("{}", error);
+        std::process::exit(code);
+    }
+
+    Ok(output)
+}
+
+/// Execute a command with a timeout.
+fn execute_command_with_timeout(
+    command: &str,
+    working_dir: &str,
+    env_vars: Option<HashMap<String, String>>,
+    timeout: u64,
+    verbosity: u8,
+) -> Result<String> {
+    let timeout_duration = Duration::from_secs(timeout);
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(command)
+        .current_dir(working_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(vars) = env_vars {
+        for (key, value) in vars {
+            cmd.env(key, value);
+        }
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| Error::other(format!("Failed to spawn command: {}", e)))?;
+
+    match child.wait_timeout(timeout_duration) {
+        Ok(Some(status)) => {
+            let mut stdout = String::new();
+            let mut stderr = String::new();
+
+            if let Some(mut out) = child.stdout.take() {
+                out.read_to_string(&mut stdout)
+                    .map_err(|e| Error::other(format!("Failed to read stdout: {}", e)))?;
+            }
+            if let Some(mut err) = child.stderr.take() {
+                err.read_to_string(&mut stderr)
+                    .map_err(|e| Error::other(format!("Failed to read stderr: {}", e)))?;
+            }
+
+            let code = status.code().unwrap_or(-1);
+
+            if verbosity > 1 {
+                info!("command status: {}", code);
+                info!("command stderr:\n{}", stderr);
+            }
+
+            if !stderr.is_empty() {
+                eprintln!("{}", stderr);
+                std::process::exit(code);
+            }
+
+            Ok(stdout)
+        }
+        Ok(None) => {
+            if verbosity > 0 {
+                warn!("Command timed out after {} seconds, killing process", timeout);
+            }
+            child
+                .kill()
+                .map_err(|e| Error::other(format!("Failed to kill timed-out process: {}", e)))?;
+            child.wait().ok();
+
+            Err(Error::other(format!(
+                "Command timed out after {} seconds",
+                timeout
+            )))
+        }
+        Err(e) => Err(Error::other(format!("Failed to wait on command: {}", e))),
     }
 }
 


### PR DESCRIPTION
## Summary
Add support for watching [Radicle](https://radicle.xyz) repositories via their HTTP API, enabling GOA to trigger CI jobs for decentralized git projects.

### New Subcommand
```bash
goa radicle -s https://iris.radicle.xyz -r rad:z3fF7wV6LXz915ND1nbHTfeY3Qcq7 -c './run-ci.sh'
```

### Features
- Poll seed node API for head (main branch) changes
- Poll for patch (PR-equivalent) updates with `--watch-patches`
- Trigger commands on push or patch events
- Inject Radicle-specific environment variables
- State tracking to detect new/updated patches
- Full support for --timeout, --delay, --verbosity flags

### Environment Variables
| Variable | Description |
|----------|-------------|
| `GOA_RADICLE_RID` | Repository ID |
| `GOA_RADICLE_URL` | Seed node URL |
| `GOA_TRIGGER_TYPE` | `push` or `patch` |
| `GOA_COMMIT_OID` | Commit SHA to test |
| `GOA_PATCH_ID` | Patch ID (if patch trigger) |
| `GOA_BASE_COMMIT` | Base commit for patches |
| `GOA_PATCH_STATE` | Patch state |
| `GOA_PATCH_TITLE` | Patch title |

### Dependencies Added
- `reqwest` - HTTP client with blocking + JSON support
- `serde`, `serde_json` - JSON serialization

## Test plan
- [x] All unit tests pass (12 tests including 3 new Radicle tests)
- [x] All CLI integration tests pass (9 tests)
- [x] `cargo clippy` passes (only unused getter warnings - expected)
- [x] Build succeeds
- [x] `goa radicle --help` shows correct options
- [ ] Manual testing against live Radicle seed node

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)