### PR TITLE
fix: use last() instead of first() for patch revision detection

### DIFF
--- a/src/radicle/mod.rs
+++ b/src/radicle/mod.rs
@@ -267,7 +267,7 @@ pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
     if config.watch_patches() {
         if let Ok(patches) = fetch_patches(&client, &config) {
             for patch in patches {
-                if let Some(rev) = patch.revisions.first() {
+                if let Some(rev) = patch.revisions.last() {
                     state.last_patch_timestamps.insert(patch.id.clone(), rev.timestamp);
                 }
             }
@@ -390,7 +390,7 @@ fn check_for_changes(
                     continue;
                 }
 
-                if let Some(rev) = patch.revisions.first() {
+                if let Some(rev) = patch.revisions.last() {
                     let last_timestamp = state.last_patch_timestamps.get(&patch.id).copied();
 
                     let is_new_or_updated = match last_timestamp {


### PR DESCRIPTION
## Summary
Fixes #128

When detecting Radicle patch updates, goa was checking the timestamp of the first revision instead of the last. This meant new revisions added via `rad patch update` were not detected.

## Changes
- Line 270: Initial state tracking now uses `.last()` 
- Line 393: Change detection loop now uses `.last()`

## Test plan
- [x] All existing tests pass
- [ ] Manual testing with Radicle patch updates (requires Radicle environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)