### PR TITLE
fix: don't exit process on stderr output

### DIFF
--- a/src/repos.rs
+++ b/src/repos.rs
@@ -330,12 +330,19 @@ pub fn execute_command(
 
     if verbosity > 1 {
         info!("command status: {}", code);
-        info!("command stderr:\n{}", error);
+        if !error.is_empty() {
+            info!("command stderr:\n{}", error);
+        }
     }
 
+    // Print stderr but don't exit - many commands write progress to stderr
     if !error.is_empty() {
         eprintln!("{}", error);
-        std::process::exit(code);
+    }
+
+    // Return error only if command failed (non-zero exit code)
+    if code != 0 {
+        return Err(Error::other(format!("Command exited with code {}", code)));
     }
 
     Ok(output)
@@ -386,12 +393,19 @@ fn execute_command_with_timeout(
 
             if verbosity > 1 {
                 info!("command status: {}", code);
-                info!("command stderr:\n{}", stderr);
+                if !stderr.is_empty() {
+                    info!("command stderr:\n{}", stderr);
+                }
             }
 
+            // Print stderr but don't exit - many commands write progress to stderr
             if !stderr.is_empty() {
                 eprintln!("{}", stderr);
-                std::process::exit(code);
+            }
+
+            // Return error only if command failed (non-zero exit code)
+            if code != 0 {
+                return Err(Error::other(format!("Command exited with code {}", code)));
             }
 
             Ok(stdout)


### PR DESCRIPTION
## Summary
Fixes #132

The `execute_command` function was calling `process::exit()` whenever a command wrote anything to stderr, even on successful execution. Many tools (cargo, npm, git, etc.) write progress info to stderr, causing goa to exit prematurely.

## Changes
- Print stderr output but continue execution
- Only return error if exit code is non-zero
- Applies to both timeout and non-timeout code paths

## Impact
This bug affected both `spy` and `radicle` subcommands, but was more visible with Radicle since CI commands typically produce stderr output.

## Test plan
- [x] All 32 tests pass
- [x] Clippy clean
- [ ] Manual testing with command that writes to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)