### PR TITLE
chore: release 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitops-agent"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["kitplummer@gmail.com"]
 description = "GitOps Agent - continuously monitors a remote git repository against local/any change, and performs actions (e.g. executes a provided command) - given a periodicity that is defined as a time intervals."


### PR DESCRIPTION
## Summary
Patch release with bug fixes and documentation.

## Changes since 0.1.0
- **fix**: don't exit process on stderr output (#133) - Fixes Radicle watcher exiting after CI
- **docs**: add release process documentation (#134) - RELEASING.md
- **fix**: update release workflow to use GITHUB_TOKEN (#135) - No more custom secrets needed

## Release checklist
- [ ] Merge this PR
- [ ] Tag: `git tag v0.1.1 && git push origin v0.1.1`
- [ ] Verify GHA release workflow completes
- [ ] Publish: `cargo publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)