### PR TITLE
fix: production readiness P0/P1 improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,22 +11,18 @@ env:
 
 jobs:
   build_n_lint:
-    
+
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/checkout@v4
     - name: Install latest rust toolchain
-      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-      with:
-        toolchain: stable
-        default: true
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: cargo build
       run: cargo build --verbose
     - name: cargo clippy
       run: cargo clippy --verbose
-    
+
   functional_test:
     strategy:
       matrix:
@@ -35,12 +31,18 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/checkout@v4
     - name: Install latest rust toolchain
-      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-      with:
-        toolchain: stable
-        default: true
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: cargo test
       run: export TMPDIR=$HOME; cargo test --verbose
+
+  security_audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install cargo-audit
+      run: cargo install cargo-audit
+    - name: Run security audit
+      run: cargo audit

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@c1aec4ac820532bab364f02a81873c555a0ba3a1 # v1.0.2
+        uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -42,7 +42,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif
@@ -50,6 +50,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@d39d5d5c9707b926d517b1b292905ef4c03aa777 # v1.0.26
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,10 @@ extern crate log;
 
 use env_logger::{Builder, Env, Target};
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let CommandLineArgs { action } = CommandLineArgs::parse();
 
-    match action {
+    let result = match action {
         Spy {
             url,
             branch,
@@ -97,9 +97,23 @@ fn main() -> anyhow::Result<()> {
 
             radicle::watch_radicle(config)
         }
-    }?;
+    };
 
-    Ok(())
+    if let Err(e) = result {
+        let msg = e.to_string();
+        eprintln!("{}", msg);
+
+        // Forward the child process exit code if available
+        let code = parse_exit_code(&msg).unwrap_or(1);
+        std::process::exit(code);
+    }
+}
+
+/// Extract exit code from error messages containing "Command exited with code 127"
+fn parse_exit_code(msg: &str) -> Option<i32> {
+    let marker = "Command exited with code ";
+    let start = msg.find(marker)? + marker.len();
+    msg[start..].split_whitespace().next()?.parse().ok()
 }
 
 fn init_logger(verbosity: u8) {

--- a/src/radicle/mod.rs
+++ b/src/radicle/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::{Error, Result};
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
@@ -435,7 +436,10 @@ fn execute_radicle_command(config: &RadicleConfig, metadata: &RadicleMetadata) -
         None => {
             // Try to read from local .goa file if local_path is set
             match config.local_path() {
-                Some(path) => read_goa_file(&format!("{}/.goa", path)),
+                Some(path) => {
+                    let goa_path = PathBuf::from(path).join(".goa");
+                    read_goa_file(&goa_path.to_string_lossy())
+                }
                 None => {
                     return Err(Error::other(
                         "No command specified and no local path for .goa file",

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{Error, Read as IoRead, Result};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -258,6 +259,8 @@ impl Repo {
         let mut scheduler = Scheduler::new();
         let delay = self.delay as u32;
         let cloned_repo = Arc::new(Mutex::new(self.clone()));
+        let should_exit = Arc::new(AtomicBool::new(false));
+        let exit_flag = Arc::clone(&should_exit);
 
         if self.exec_on_start {
             let repo_guard = cloned_repo
@@ -280,8 +283,15 @@ impl Repo {
         scheduler.every(delay.seconds()).run(move || {
             match cloned_repo.lock() {
                 Ok(repo_guard) => {
-                    if let Err(e) = do_process(&repo_guard) {
-                        eprintln!("goa error: unable to process repo: {}", e);
+                    match do_process(&repo_guard) {
+                        Ok(should_stop) => {
+                            if should_stop {
+                                exit_flag.store(true, Ordering::SeqCst);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("goa error: unable to process repo: {}", e);
+                        }
                     }
                 }
                 Err(e) => {
@@ -293,6 +303,10 @@ impl Repo {
         // Manually run the scheduler in an event loop
         loop {
             scheduler.run_pending();
+            if should_exit.load(Ordering::SeqCst) {
+                info!("exiting after first diff processed");
+                return Ok(());
+            }
             thread::sleep(Duration::from_millis(10));
         }
     }
@@ -447,7 +461,10 @@ fn execute_command_with_timeout(
 fn get_effective_command(repo: &Repo, local_path: &str) -> String {
     match repo.command() {
         Some(cmd) => cmd.to_string(),
-        None => read_goa_file(&format!("{}/.goa", local_path)),
+        None => {
+            let goa_path = PathBuf::from(local_path).join(".goa");
+            read_goa_file(&goa_path.to_string_lossy())
+        }
     }
 }
 
@@ -470,22 +487,18 @@ pub fn do_process_once(repo: &Repo) -> Result<()> {
         debug!("effective command: {}", effective_command);
     }
 
-    match do_task(repo, &effective_command, Some(&metadata)) {
-        Ok(output) => {
-            if repo.verbosity() > 0 {
-                info!("command stdout: {}", output);
-            } else {
-                println!("{output}");
-            }
-        }
-        Err(e) => {
-            eprintln!("goa error: do_task error {}", e);
-        }
+    let output = do_task(repo, &effective_command, Some(&metadata))?;
+    if repo.verbosity() > 0 {
+        info!("command stdout: {}", output);
+    } else {
+        println!("{output}");
     }
     Ok(())
 }
 
-pub fn do_process(repo: &Repo) -> Result<()> {
+/// Process a single check cycle. Returns Ok(true) if the caller should stop
+/// (e.g., exit_on_first_diff), Ok(false) to continue, or Err on fatal errors.
+pub fn do_process(repo: &Repo) -> Result<bool> {
     let local_path = repo
         .local_path()
         .ok_or_else(|| Error::other("local_path is not set"))?;
@@ -541,8 +554,7 @@ pub fn do_process(repo: &Repo) -> Result<()> {
                             }
 
                             if repo.exit_on_first_diff() {
-                                // Intentional exit after first diff processed
-                                std::process::exit(0);
+                                return Ok(true);
                             }
                         }
                         Err(e) => {
@@ -563,7 +575,7 @@ pub fn do_process(repo: &Repo) -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(false)
 }
 
 /// Execute a command with optional commit metadata passed as env vars to child process.
@@ -607,13 +619,19 @@ fn do_task(repo: &Repo, command: &str, metadata: Option<&CommitMetadata>) -> Res
 
     if repo.verbosity() > 1 {
         info!("command status: {}", code);
-        info!("command stderr:\n{}", error);
+        if !error.is_empty() {
+            info!("command stderr:\n{}", error);
+        }
     }
 
+    // Print stderr but don't exit - many commands write progress/warnings to stderr
     if !error.is_empty() {
         eprintln!("{}", error);
-        // Exit with the command's exit code - this is intentional behavior
-        std::process::exit(code);
+    }
+
+    // Return error only if command failed (non-zero exit code)
+    if code != 0 {
+        return Err(Error::other(format!("Command exited with code {}", code)));
     }
 
     Ok(output)
@@ -667,13 +685,19 @@ fn do_task_with_timeout(
 
             if repo.verbosity() > 1 {
                 info!("command status: {}", code);
-                info!("command stderr:\n{}", stderr);
+                if !stderr.is_empty() {
+                    info!("command stderr:\n{}", stderr);
+                }
             }
 
+            // Print stderr but don't exit - many commands write progress/warnings to stderr
             if !stderr.is_empty() {
                 eprintln!("{}", stderr);
-                // Exit with the command's exit code - this is intentional behavior
-                std::process::exit(code);
+            }
+
+            // Return error only if command failed (non-zero exit code)
+            if code != 0 {
+                return Err(Error::other(format!("Command exited with code {}", code)));
             }
 
             Ok(stdout)
@@ -756,7 +780,7 @@ mod repos_tests {
 
         repo.clone_repo()?;
 
-        assert_eq!(do_process(&repo)?, ());
+        assert_eq!(do_process(&repo)?, false);
         Ok(())
     }
 
@@ -798,7 +822,7 @@ mod repos_tests {
 
         repo.clone_repo()?;
 
-        assert_eq!(do_process(&repo)?, ());
+        assert_eq!(do_process(&repo)?, false);
         Ok(())
     }
 

--- a/src/spy/mod.rs
+++ b/src/spy/mod.rs
@@ -35,15 +35,15 @@ pub fn spy_repo(mut repo: Repo) -> Result<()> {
 
     if repo.local_path().is_none() {
         // Get a temp directory to do work in
-        let temp = temp_dir();
-        let local_path = temp
-            .into_os_string()
-            .into_string()
-            .map_err(|_| Error::other("Failed to convert temp directory path to string"))?;
-        let tmp_dir_name = format!("{}/{}/", local_path, Uuid::new_v4());
+        let tmp_dir_name = temp_dir()
+            .join(Uuid::new_v4().to_string());
+        let local_path = tmp_dir_name
+            .to_str()
+            .ok_or_else(|| Error::other("Failed to convert temp directory path to string"))?
+            .to_string();
 
         // Set the local repo path in the repo struct
-        repo.set_local_path(tmp_dir_name);
+        repo.set_local_path(local_path);
     }
 
     // Clone the repo and set the local path


### PR DESCRIPTION
## Summary

- **Replace `process::exit()` with proper error propagation** (#138) — `do_task` and `do_task_with_timeout` no longer terminate the process when commands write to stderr. Exit is based on exit code, not stderr presence. `exit_on_first_diff` uses `AtomicBool` to cleanly break the scheduler loop. Child process exit codes are forwarded through `main()`.
- **Use `PathBuf` for file path construction** (#145) — `.goa` file paths and temp directory paths now use `PathBuf::join()` instead of `format!()`, fixing cross-platform correctness (Windows).
- **Upgrade stale GitHub Actions** (#142) — `rust.yml` and `scorecards-analysis.yml` updated from archived/outdated actions (`actions-rs/toolchain`, checkout v2) to current versions (`dtolnay/rust-toolchain`, checkout v4, scorecard v2, codeql v3).
- **Add `cargo-audit` security scanning to CI** (#141) — New `security_audit` job in `rust.yml` runs `cargo audit` on every push and PR.

## Test plan

- [x] All 24 unit tests pass
- [x] All 16 integration tests pass (including `test_spy_repo_command_bad_command` which validates exit code 127 forwarding)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Verify CI workflows run successfully on this PR

Closes #138, closes #141, closes #142, closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)