### PR TITLE
feat: structured tracing, retry with backoff, test fixture decoupling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build
-        run: cargo build --all --release && strip target/release/goa && mv target/release/goa target/release/goa_amd64
+        run: cargo build --all --release && mv target/release/goa target/release/goa_amd64
 
       - name: Build Changelog
         id: github_release
@@ -134,7 +134,7 @@ jobs:
           targets: x86_64-apple-darwin
 
       - name: Build for mac
-        run: cargo build --all --release && strip target/release/goa && mv target/release/goa target/release/goa_darwin
+        run: cargo build --all --release && mv target/release/goa target/release/goa_darwin
 
       - name: Release
         uses: svenstaro/upload-release-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 anyhow = "1.0"
 chrono = "0.4"
 clokwerk = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0"
 chrono = "0.4"
 clokwerk = "0.4"
 git2 = "0.20"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
@@ -33,7 +33,14 @@ wait-timeout = "0.2"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+ctrlc = "3"
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: build test lint coverage clean release help
+.PHONY: build test test-all lint coverage clean release help
 
 help:
 	@echo "Available targets:"
 	@echo "  build     - Build the project in debug mode"
 	@echo "  release   - Build the project in release mode"
-	@echo "  test      - Run all tests"
+	@echo "  test      - Run fast tests (no network)"
+	@echo "  test-all  - Run all tests including network-dependent ones"
 	@echo "  lint      - Run clippy linter"
 	@echo "  coverage  - Generate test coverage report (requires cargo-llvm-cov)"
 	@echo "  clean     - Clean build artifacts"
@@ -17,6 +18,9 @@ release:
 
 test:
 	cargo test
+
+test-all:
+	cargo test -- --include-ignored
 
 lint:
 	cargo clippy -- -D warnings

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,10 +13,10 @@ pub enum Action {
         #[arg(short, long, default_value = "120")]
         delay: u16,
         /// Username, owner of the token - required for private repos
-        #[arg(short, long)]
+        #[arg(short, long, env = "GOA_USERNAME")]
         username: Option<String>,
         /// The access token for cloning and fetching of the remote repo
-        #[arg(short, long)]
+        #[arg(short, long, env = "GOA_TOKEN")]
         token: Option<String>,
         /// The command to run when a change is detected
         #[arg(short, long, default_value = "")]
@@ -40,7 +40,7 @@ pub enum Action {
         #[arg(long)]
         lei_url: Option<String>,
         /// Bearer token for LEI API authentication
-        #[arg(long)]
+        #[arg(long, env = "GOA_LEI_TOKEN")]
         lei_token: Option<String>,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,9 @@ pub enum Action {
         /// Bearer token for LEI API authentication
         #[arg(long, env = "GOA_LEI_TOKEN")]
         lei_token: Option<String>,
+        /// Output logs in JSON format (for structured log ingestion)
+        #[arg(long)]
+        json: bool,
     },
 
     /// Watch a Radicle repository for changes via HTTP API
@@ -70,6 +73,9 @@ pub enum Action {
         /// Local working directory for command execution and .goa file
         #[arg(short = 'l', long)]
         local_path: Option<String>,
+        /// Output logs in JSON format (for structured log ingestion)
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -31,14 +31,27 @@ pub struct CommitMetadata {
     pub time: String,
 }
 
+/// Sanitize a string for safe use as an environment variable value.
+/// Strips control characters (null bytes, tabs, carriage returns) and
+/// truncates to a maximum length to prevent abuse via crafted commit metadata.
+pub fn sanitize_env_value(value: &str) -> String {
+    const MAX_ENV_VALUE_LEN: usize = 4096;
+    value
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\n')
+        .take(MAX_ENV_VALUE_LEN)
+        .collect()
+}
+
 impl CommitMetadata {
-    /// Convert to a HashMap suitable for passing to child process environment
+    /// Convert to a HashMap suitable for passing to child process environment.
+    /// Values are sanitized to strip control characters and enforce length limits.
     pub fn to_env_vars(&self) -> HashMap<String, String> {
         let mut vars = HashMap::new();
-        vars.insert("GOA_LAST_COMMIT_ID".to_string(), self.id.clone());
-        vars.insert("GOA_LAST_COMMIT_AUTHOR".to_string(), self.author.clone());
-        vars.insert("GOA_LAST_COMMIT_MESSAGE".to_string(), self.message.clone());
-        vars.insert("GOA_LAST_COMMIT_TIME".to_string(), self.time.clone());
+        vars.insert("GOA_LAST_COMMIT_ID".to_string(), sanitize_env_value(&self.id));
+        vars.insert("GOA_LAST_COMMIT_AUTHOR".to_string(), sanitize_env_value(&self.author));
+        vars.insert("GOA_LAST_COMMIT_MESSAGE".to_string(), sanitize_env_value(&self.message));
+        vars.insert("GOA_LAST_COMMIT_TIME".to_string(), sanitize_env_value(&self.time));
         vars
     }
 }
@@ -424,9 +437,29 @@ mod tests {
 
         let vars = metadata.to_env_vars();
 
+        // Newlines are preserved, quotes and ampersands pass through
         assert_eq!(
             vars.get("GOA_LAST_COMMIT_MESSAGE"),
             Some(&"Fix: handle \"special\" chars & newlines\nLine 2".to_string())
         );
+    }
+
+    #[test]
+    fn test_sanitize_env_value_strips_control_chars() {
+        // Null bytes, tabs, carriage returns should be stripped
+        assert_eq!(sanitize_env_value("hello\0world"), "helloworld");
+        assert_eq!(sanitize_env_value("hello\tworld"), "helloworld");
+        assert_eq!(sanitize_env_value("hello\r\nworld"), "hello\nworld");
+        // Newlines are preserved
+        assert_eq!(sanitize_env_value("line1\nline2"), "line1\nline2");
+        // Normal text passes through
+        assert_eq!(sanitize_env_value("normal text"), "normal text");
+    }
+
+    #[test]
+    fn test_sanitize_env_value_truncates() {
+        let long_string = "a".repeat(5000);
+        let sanitized = sanitize_env_value(&long_string);
+        assert_eq!(sanitized.len(), 4096);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -20,6 +20,7 @@ use git2::{
 use std::collections::HashMap;
 use std::io::Write;
 use std::str;
+use tracing::{error, warn};
 
 /// Metadata extracted from a git commit, to be passed to child processes as env vars.
 /// This avoids global env var mutation which is not thread-safe.
@@ -131,7 +132,7 @@ pub fn is_diff<'a>(
     if diff.deltas().len() > 0 {
         if verbosity >= 2 {
             if let Err(e) = display_stats(&diff) {
-                eprintln!("Warning: unable to print diff stats: {}", e);
+                warn!("unable to print diff stats: {}", e);
             }
         }
         let fetch_head = repo.find_reference("FETCH_HEAD")?;
@@ -272,7 +273,7 @@ fn normal_merge(
     let mut idx = repo.merge_trees(&ancestor, &local_tree, &remote_tree, None)?;
 
     if idx.has_conflicts() {
-        eprintln!("Error: Merge conficts detected...");
+        error!("merge conflicts detected");
         repo.checkout_index(Some(&mut idx), None)?;
         return Ok(());
     }
@@ -342,7 +343,7 @@ pub fn do_merge<'a>(
         let commit = find_last_commit(repo)?;
         Ok(extract_commit_metadata(&commit, verbosity))
     } else {
-        eprintln!("Error: Nothing to do?");
+        warn!("merge analysis: nothing to do");
         Ok(CommitMetadata::default())
     }
 }

--- a/src/lei.rs
+++ b/src/lei.rs
@@ -3,6 +3,9 @@ use std::io::{Error, Result};
 
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::retry::retry_with_backoff;
 
 /// Known dependency/manifest file names across ecosystems.
 const DEP_FILE_NAMES: &[&str] = &[
@@ -171,28 +174,31 @@ pub fn analyze_repo(config: &LeiConfig, repo_url: &str, verbosity: u8) -> Result
         );
     }
 
-    let mut request = client.post(&url).json(&body);
+    let token = config.token.clone();
+    let analyze_resp: AnalyzeResponse = retry_with_backoff(3, 500, || {
+        let mut request = client.post(&url).json(&body);
 
-    if let Some(ref token) = config.token {
-        request = request.header("Authorization", format!("Bearer {}", token));
-    }
+        if let Some(ref token) = token {
+            request = request.header("Authorization", format!("Bearer {}", token));
+        }
 
-    let response = request
-        .send()
-        .map_err(|e| Error::other(format!("LEI request failed: {}", e)))?;
+        let response = request
+            .send()
+            .map_err(|e| Error::other(format!("LEI request failed: {}", e)))?;
 
-    let status = response.status();
-    if !status.is_success() {
-        let body_text = response.text().unwrap_or_default();
-        return Err(Error::other(format!(
-            "LEI API returned status {}: {}",
-            status, body_text
-        )));
-    }
+        let status = response.status();
+        if !status.is_success() {
+            let body_text = response.text().unwrap_or_default();
+            return Err(Error::other(format!(
+                "LEI API returned status {}: {}",
+                status, body_text
+            )));
+        }
 
-    let analyze_resp: AnalyzeResponse = response
-        .json()
-        .map_err(|e| Error::other(format!("Failed to parse LEI response: {}", e)))?;
+        response
+            .json()
+            .map_err(|e| Error::other(format!("Failed to parse LEI response: {}", e)))
+    })?;
 
     if verbosity > 0 {
         log_analysis_summary(&analyze_resp, repo_url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod git;
 mod lei;
 mod radicle;
 mod repos;
+mod retry;
 mod spy;
 
 use crate::lei::LeiConfig;
@@ -10,11 +11,8 @@ use crate::radicle::RadicleConfig;
 use crate::repos::Repo;
 use clap::Parser;
 use cli::{Action::*, CommandLineArgs};
-
-#[macro_use]
-extern crate log;
-
-use env_logger::{Builder, Env, Target};
+use tracing::info;
+use tracing_subscriber::{fmt, EnvFilter};
 
 fn main() {
     let CommandLineArgs { action } = CommandLineArgs::parse();
@@ -34,6 +32,7 @@ fn main() {
             timeout,
             lei_url,
             lei_token,
+            json,
         } => {
             let mut builder = Repo::builder(&url)
                 .branch(branch)
@@ -63,7 +62,7 @@ fn main() {
 
             let repo = builder.build();
 
-            init_logger(verbosity);
+            init_tracing(verbosity, json);
             info!("starting");
 
             spy::spy_repo(repo)
@@ -78,6 +77,7 @@ fn main() {
             timeout,
             watch_patches,
             local_path,
+            json,
         } => {
             let mut builder = RadicleConfig::builder(&seed_url, &rid)
                 .delay(delay)
@@ -92,7 +92,7 @@ fn main() {
 
             let config = builder.build();
 
-            init_logger(verbosity);
+            init_tracing(verbosity, json);
             info!("starting radicle watcher");
 
             radicle::watch_radicle(config)
@@ -116,14 +116,27 @@ fn parse_exit_code(msg: &str) -> Option<i32> {
     msg[start..].split_whitespace().next()?.parse().ok()
 }
 
-fn init_logger(verbosity: u8) {
+fn init_tracing(verbosity: u8, json: bool) {
     let log_level = match verbosity {
         0 => "error",
         1 => "info",
         _ => "debug",
     };
 
-    Builder::from_env(Env::default().default_filter_or(log_level))
-        .target(Target::Stdout)
-        .init();
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(log_level));
+
+    if json {
+        fmt::Subscriber::builder()
+            .with_env_filter(env_filter)
+            .with_target(true)
+            .with_thread_ids(true)
+            .json()
+            .init();
+    } else {
+        fmt::Subscriber::builder()
+            .with_env_filter(env_filter)
+            .with_target(false)
+            .init();
+    }
 }

--- a/src/radicle/mod.rs
+++ b/src/radicle/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::io::{Error, Result};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -9,6 +11,7 @@ use serde::Deserialize;
 
 use clokwerk::{Scheduler, TimeUnits};
 
+use crate::git::sanitize_env_value;
 use crate::repos::{execute_command, read_goa_file};
 
 /// Radicle repository configuration
@@ -149,22 +152,22 @@ pub struct RadicleMetadata {
 impl RadicleMetadata {
     pub fn to_env_vars(&self) -> HashMap<String, String> {
         let mut vars = HashMap::new();
-        vars.insert("GOA_RADICLE_RID".to_string(), self.rid.clone());
-        vars.insert("GOA_RADICLE_URL".to_string(), self.seed_url.clone());
-        vars.insert("GOA_TRIGGER_TYPE".to_string(), self.trigger_type.clone());
-        vars.insert("GOA_COMMIT_OID".to_string(), self.commit_oid.clone());
+        vars.insert("GOA_RADICLE_RID".to_string(), sanitize_env_value(&self.rid));
+        vars.insert("GOA_RADICLE_URL".to_string(), sanitize_env_value(&self.seed_url));
+        vars.insert("GOA_TRIGGER_TYPE".to_string(), sanitize_env_value(&self.trigger_type));
+        vars.insert("GOA_COMMIT_OID".to_string(), sanitize_env_value(&self.commit_oid));
 
         if let Some(ref patch_id) = self.patch_id {
-            vars.insert("GOA_PATCH_ID".to_string(), patch_id.clone());
+            vars.insert("GOA_PATCH_ID".to_string(), sanitize_env_value(patch_id));
         }
         if let Some(ref base) = self.base_commit {
-            vars.insert("GOA_BASE_COMMIT".to_string(), base.clone());
+            vars.insert("GOA_BASE_COMMIT".to_string(), sanitize_env_value(base));
         }
         if let Some(ref state) = self.patch_state {
-            vars.insert("GOA_PATCH_STATE".to_string(), state.clone());
+            vars.insert("GOA_PATCH_STATE".to_string(), sanitize_env_value(state));
         }
         if let Some(ref title) = self.patch_title {
-            vars.insert("GOA_PATCH_TITLE".to_string(), title.clone());
+            vars.insert("GOA_PATCH_TITLE".to_string(), sanitize_env_value(title));
         }
 
         vars
@@ -278,6 +281,14 @@ pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
         }
     }
 
+    // Set up signal handler for graceful shutdown
+    let should_exit = Arc::new(AtomicBool::new(false));
+    let signal_flag = Arc::clone(&should_exit);
+    ctrlc::set_handler(move || {
+        signal_flag.store(true, Ordering::SeqCst);
+    })
+    .map_err(|e| Error::other(format!("Failed to set signal handler: {}", e)))?;
+
     // Set up scheduler
     let mut scheduler = Scheduler::new();
     let delay = config.delay() as u32;
@@ -291,6 +302,10 @@ pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
     // Event loop
     loop {
         scheduler.run_pending();
+        if should_exit.load(Ordering::SeqCst) {
+            info!("shutting down gracefully");
+            return Ok(());
+        }
         thread::sleep(Duration::from_millis(10));
     }
 }

--- a/src/radicle/mod.rs
+++ b/src/radicle/mod.rs
@@ -8,11 +8,13 @@ use std::time::Duration;
 
 use reqwest::blocking::Client;
 use serde::Deserialize;
+use tracing::{debug, error, info};
 
 use clokwerk::{Scheduler, TimeUnits};
 
 use crate::git::sanitize_env_value;
 use crate::repos::{execute_command, read_goa_file};
+use crate::retry::retry_with_backoff;
 
 /// Radicle repository configuration
 #[derive(Debug, Clone)]
@@ -261,7 +263,7 @@ pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
     let mut state = WatchState::default();
 
     // Do initial fetch to establish baseline
-    if let Ok(repo_info) = fetch_repo_info(&client, &config) {
+    if let Ok(repo_info) = retry_with_backoff(3, 500, || fetch_repo_info(&client, &config)) {
         state.last_head = Some(repo_info.payloads.project.meta.head.clone());
         if config.verbosity() > 0 {
             info!("initial head: {}", repo_info.payloads.project.meta.head);
@@ -269,7 +271,7 @@ pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
     }
 
     if config.watch_patches() {
-        if let Ok(patches) = fetch_patches(&client, &config) {
+        if let Ok(patches) = retry_with_backoff(3, 500, || fetch_patches(&client, &config)) {
             for patch in patches {
                 if let Some(rev) = patch.revisions.last() {
                     state.last_patch_timestamps.insert(patch.id.clone(), rev.timestamp);
@@ -295,7 +297,7 @@ pub fn watch_radicle(config: RadicleConfig) -> Result<()> {
 
     scheduler.every(delay.seconds()).run(move || {
         if let Err(e) = check_for_changes(&client, &config, &mut state) {
-            eprintln!("goa error: failed to check Radicle repo: {}", e);
+            error!("failed to check Radicle repo: {}", e);
         }
     });
 
@@ -372,7 +374,7 @@ fn check_for_changes(
     }
 
     // Check for head changes (push to main branch)
-    if let Ok(repo_info) = fetch_repo_info(client, config) {
+    if let Ok(repo_info) = retry_with_backoff(3, 500, || fetch_repo_info(client, config)) {
         let current_head = &repo_info.payloads.project.meta.head;
 
         if let Some(ref last_head) = state.last_head {
@@ -399,7 +401,7 @@ fn check_for_changes(
 
     // Check for patch changes
     if config.watch_patches() {
-        if let Ok(patches) = fetch_patches(client, config) {
+        if let Ok(patches) = retry_with_backoff(3, 500, || fetch_patches(client, config)) {
             for patch in patches {
                 // Only process open patches
                 if patch.state.status != "open" {
@@ -486,7 +488,7 @@ fn execute_radicle_command(config: &RadicleConfig, metadata: &RadicleMetadata) -
             Ok(())
         }
         Err(e) => {
-            eprintln!("goa error: command failed: {}", e);
+            error!("command failed: {}", e);
             Ok(()) // Don't stop watching on command failure
         }
     }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -262,6 +262,13 @@ impl Repo {
         let should_exit = Arc::new(AtomicBool::new(false));
         let exit_flag = Arc::clone(&should_exit);
 
+        // Register signal handler for graceful shutdown
+        let signal_flag = Arc::clone(&should_exit);
+        ctrlc::set_handler(move || {
+            signal_flag.store(true, Ordering::SeqCst);
+        })
+        .map_err(|e| Error::other(format!("Failed to set signal handler: {}", e)))?;
+
         if self.exec_on_start {
             let repo_guard = cloned_repo
                 .lock()
@@ -304,7 +311,7 @@ impl Repo {
         loop {
             scheduler.run_pending();
             if should_exit.load(Ordering::SeqCst) {
-                info!("exiting after first diff processed");
+                info!("shutting down gracefully");
                 return Ok(());
             }
             thread::sleep(Duration::from_millis(10));

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 // For processing the command
 use run_script::ScriptOptions;
+use tracing::{debug, error, info, warn};
 use wait_timeout::ChildExt;
 
 // Scheduler, and trait for .seconds(), .minutes(), etc.
@@ -18,6 +19,7 @@ use git2::Repository;
 
 use crate::git::{self, CommitMetadata};
 use crate::lei::LeiConfig;
+use crate::retry::retry_with_backoff;
 
 /// Repository configuration for monitoring a git repository.
 /// Use `RepoBuilder` to construct instances.
@@ -236,18 +238,22 @@ impl Repo {
 
         // Some OS-specific non-sense with trailing / in paths
         let local_target = str::replace(local_path, "//", "/");
-        match Repository::clone(&self.url, local_target) {
-            Ok(_repo) => {
-                if self.verbosity > 0 {
-                    info!("cloned remote repo to {}", local_path);
+        let url = self.url.clone();
+        let target = local_target.clone();
+        retry_with_backoff(3, 500, move || {
+            match Repository::clone(&url, &target) {
+                Ok(_repo) => Ok(()),
+                Err(e) => {
+                    let msg = format!("goa error: failed to clone -> {}", e);
+                    Err(Error::other(msg))
                 }
-                Ok(())
             }
-            Err(e) => {
-                let msg = format!("goa error: failed to clone -> {}", e);
-                Err(Error::other(msg))
-            }
+        })?;
+
+        if self.verbosity > 0 {
+            info!("cloned remote repo to {}", local_path);
         }
+        Ok(())
     }
 
     pub fn spy_for_changes(&self) -> Result<()> {
@@ -297,12 +303,12 @@ impl Repo {
                             }
                         }
                         Err(e) => {
-                            eprintln!("goa error: unable to process repo: {}", e);
+                            error!("unable to process repo: {}", e);
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("goa error: failed to acquire lock: {}", e);
+                    error!("failed to acquire lock: {}", e);
                 }
             }
         });
@@ -371,9 +377,9 @@ pub fn execute_command(
         }
     }
 
-    // Print stderr but don't exit - many commands write progress to stderr
+    // Log stderr but don't exit - many commands write progress to stderr
     if !error.is_empty() {
-        eprintln!("{}", error);
+        warn!("command stderr: {}", error);
     }
 
     // Return error only if command failed (non-zero exit code)
@@ -434,9 +440,9 @@ fn execute_command_with_timeout(
                 }
             }
 
-            // Print stderr but don't exit - many commands write progress to stderr
+            // Log stderr but don't exit - many commands write progress to stderr
             if !stderr.is_empty() {
-                eprintln!("{}", stderr);
+                warn!("command stderr: {}", stderr);
             }
 
             // Return error only if command failed (non-zero exit code)
@@ -537,7 +543,7 @@ pub fn do_process(repo: &Repo) -> Result<bool> {
                             }
                         }
                         Err(e) => {
-                            eprintln!("goa warning: LEI analysis failed: {}", e);
+                            warn!("LEI analysis failed: {}", e);
                         }
                     }
                 }
@@ -565,12 +571,12 @@ pub fn do_process(repo: &Repo) -> Result<bool> {
                             }
                         }
                         Err(e) => {
-                            eprintln!("goa error: do_task error {}", e);
+                            error!("do_task error: {}", e);
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("goa error: do_merge error {}", e);
+                    error!("do_merge error: {}", e);
                 }
             }
         }
@@ -631,9 +637,9 @@ fn do_task(repo: &Repo, command: &str, metadata: Option<&CommitMetadata>) -> Res
         }
     }
 
-    // Print stderr but don't exit - many commands write progress/warnings to stderr
+    // Log stderr but don't exit - many commands write progress/warnings to stderr
     if !error.is_empty() {
-        eprintln!("{}", error);
+        warn!("command stderr: {}", error);
     }
 
     // Return error only if command failed (non-zero exit code)
@@ -697,9 +703,9 @@ fn do_task_with_timeout(
                 }
             }
 
-            // Print stderr but don't exit - many commands write progress/warnings to stderr
+            // Log stderr but don't exit - many commands write progress/warnings to stderr
             if !stderr.is_empty() {
-                eprintln!("{}", stderr);
+                warn!("command stderr: {}", stderr);
             }
 
             // Return error only if command failed (non-zero exit code)
@@ -772,6 +778,7 @@ mod repos_tests {
     }
 
     #[test]
+    #[ignore] // requires network access to github.com
     fn test_do_process() -> Result<()> {
         let temp_dir = std::env::temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
@@ -792,6 +799,7 @@ mod repos_tests {
     }
 
     #[test]
+    #[ignore] // requires network access to github.com
     fn test_do_process_no_clone() -> Result<()> {
         let temp_dir = std::env::temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
@@ -814,6 +822,7 @@ mod repos_tests {
     }
 
     #[test]
+    #[ignore] // requires network access to github.com
     fn test_do_process_no_command() -> Result<()> {
         let temp_dir = std::env::temp_dir();
         let mut local_path: String = temp_dir.into_os_string().into_string().unwrap();
@@ -866,5 +875,125 @@ mod repos_tests {
         let res = do_task(&repo, "sleep 10", None);
         assert!(res.is_err());
         assert!(res.unwrap_err().to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn test_clone_repo_local_fixture() -> Result<()> {
+        use git2::{Repository as Git2Repo, Signature};
+
+        // Create a local "remote" repo with a commit
+        let remote_dir = std::env::temp_dir().join(format!("goa_test_remote_{}", uuid::Uuid::new_v4()));
+        let remote_repo = Git2Repo::init(&remote_dir)
+            .map_err(|e| Error::other(format!("init remote: {}", e)))?;
+
+        // Create an initial commit so HEAD exists
+        let sig = Signature::now("Test", "test@example.com")
+            .map_err(|e| Error::other(format!("sig: {}", e)))?;
+        let tree_id = remote_repo.index()
+            .and_then(|mut idx| { idx.write_tree() })
+            .map_err(|e| Error::other(format!("tree: {}", e)))?;
+        let tree = remote_repo.find_tree(tree_id)
+            .map_err(|e| Error::other(format!("find tree: {}", e)))?;
+        remote_repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .map_err(|e| Error::other(format!("commit: {}", e)))?;
+
+        // Clone into a new directory
+        let clone_dir = std::env::temp_dir().join(format!("goa_test_clone_{}", uuid::Uuid::new_v4()));
+        let repo = Repo::builder(format!("file://{}", remote_dir.display()))
+            .local_path(clone_dir.to_string_lossy().to_string())
+            .branch("master")
+            .build();
+
+        repo.clone_repo()?;
+
+        // Verify the clone exists
+        assert!(clone_dir.join(".git").exists());
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&remote_dir);
+        let _ = std::fs::remove_dir_all(&clone_dir);
+        Ok(())
+    }
+
+    #[test]
+    fn test_do_process_local_fixture() -> Result<()> {
+        use git2::{Repository as Git2Repo, Signature};
+
+        // Create a bare "remote" repo
+        let remote_dir = std::env::temp_dir().join(format!("goa_test_remote_{}", uuid::Uuid::new_v4()));
+        let remote_repo = Git2Repo::init_bare(&remote_dir)
+            .map_err(|e| Error::other(format!("init bare: {}", e)))?;
+
+        // Create an initial commit in the bare repo
+        let sig = Signature::now("Test", "test@example.com")
+            .map_err(|e| Error::other(format!("sig: {}", e)))?;
+        let tree_id = remote_repo.treebuilder(None)
+            .and_then(|tb| tb.write())
+            .map_err(|e| Error::other(format!("tree: {}", e)))?;
+        let tree = remote_repo.find_tree(tree_id)
+            .map_err(|e| Error::other(format!("find tree: {}", e)))?;
+        remote_repo.commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[])
+            .map_err(|e| Error::other(format!("commit: {}", e)))?;
+
+        // Clone it locally
+        let clone_dir = std::env::temp_dir().join(format!("goa_test_clone_{}", uuid::Uuid::new_v4()));
+        Git2Repo::clone(&format!("file://{}", remote_dir.display()), &clone_dir)
+            .map_err(|e| Error::other(format!("clone: {}", e)))?;
+
+        let repo = Repo::builder(format!("file://{}", remote_dir.display()))
+            .local_path(clone_dir.to_string_lossy().to_string())
+            .branch("main")
+            .command("echo tested")
+            .verbosity(2)
+            .build();
+
+        // No new commits on remote, so no diff — returns Ok(false)
+        assert_eq!(do_process(&repo)?, false);
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&remote_dir);
+        let _ = std::fs::remove_dir_all(&clone_dir);
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_goa_file_from_fixture() -> Result<()> {
+        let dir = std::env::temp_dir().join(format!("goa_test_goafile_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir)?;
+        let goa_path = dir.join(".goa");
+        std::fs::write(&goa_path, "echo fixture_test")?;
+
+        let contents = read_goa_file(&goa_path.to_string_lossy());
+        assert_eq!(contents, "echo fixture_test");
+
+        let _ = std::fs::remove_dir_all(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_effective_command_with_command() {
+        let repo = Repo::builder("file://.")
+            .local_path(".")
+            .command("echo explicit")
+            .build();
+        assert_eq!(get_effective_command(&repo, "."), "echo explicit");
+    }
+
+    #[test]
+    fn test_get_effective_command_from_goa_file() -> Result<()> {
+        let dir = std::env::temp_dir().join(format!("goa_test_eff_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir)?;
+        let goa_path = dir.join(".goa");
+        std::fs::write(&goa_path, "echo from_goa")?;
+
+        let repo = Repo::builder("file://.")
+            .local_path(dir.to_string_lossy().to_string())
+            .build();
+
+        let cmd = get_effective_command(&repo, &dir.to_string_lossy());
+        assert_eq!(cmd, "echo from_goa");
+
+        let _ = std::fs::remove_dir_all(&dir);
+        Ok(())
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,94 @@
+use std::thread;
+use std::time::Duration;
+
+use tracing::warn;
+
+/// Retry a fallible operation with exponential backoff.
+///
+/// - `max_retries`: number of retry attempts after the first failure (default: 3)
+/// - `base_delay_ms`: initial delay in milliseconds, doubled each attempt (default: 500)
+/// - Delay is capped at 30 seconds per attempt.
+/// - Each retry is logged at `warn!` level.
+pub fn retry_with_backoff<T, E, F>(max_retries: u32, base_delay_ms: u64, mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    E: std::fmt::Display,
+{
+    const MAX_DELAY_MS: u64 = 30_000;
+
+    let mut attempt = 0u32;
+    loop {
+        match f() {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                if attempt >= max_retries {
+                    return Err(e);
+                }
+                let delay_ms = base_delay_ms
+                    .saturating_mul(2u64.saturating_pow(attempt))
+                    .min(MAX_DELAY_MS);
+                warn!(
+                    "attempt {}/{} failed: {}; retrying in {}ms",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                    delay_ms
+                );
+                thread::sleep(Duration::from_millis(delay_ms));
+                attempt += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn test_succeeds_immediately() {
+        let result = retry_with_backoff(3, 10, || Ok::<_, String>(42));
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_fails_then_succeeds() {
+        let count = Cell::new(0u32);
+        let result = retry_with_backoff(3, 10, || {
+            let c = count.get();
+            count.set(c + 1);
+            if c < 2 {
+                Err(format!("fail #{}", c))
+            } else {
+                Ok("ok")
+            }
+        });
+        assert_eq!(result.unwrap(), "ok");
+        assert_eq!(count.get(), 3);
+    }
+
+    #[test]
+    fn test_exhausts_retries() {
+        let count = Cell::new(0u32);
+        let result = retry_with_backoff(2, 10, || {
+            let c = count.get();
+            count.set(c + 1);
+            Err::<(), _>(format!("fail #{}", c))
+        });
+        assert!(result.is_err());
+        // 1 initial + 2 retries = 3 total attempts
+        assert_eq!(count.get(), 3);
+    }
+
+    #[test]
+    fn test_zero_retries_means_single_attempt() {
+        let count = Cell::new(0u32);
+        let result = retry_with_backoff(0, 10, || {
+            count.set(count.get() + 1);
+            Err::<(), _>("always fails".to_string())
+        });
+        assert!(result.is_err());
+        assert_eq!(count.get(), 1);
+    }
+}

--- a/src/spy/mod.rs
+++ b/src/spy/mod.rs
@@ -1,6 +1,7 @@
 use std::env::temp_dir;
 use std::io::{Error, Result};
 
+use tracing::info;
 use url::Url;
 use uuid::Uuid;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -19,6 +19,7 @@ fn test_spy_repo_command_bad_url() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[ignore] // requires network access to github.com
 fn test_spy_repo_command_missing_auth() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");
@@ -32,6 +33,7 @@ fn test_spy_repo_command_missing_auth() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[test]
+#[ignore] // requires network access to github.com
 fn test_spy_repo_command_bad_auth() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");
@@ -47,6 +49,7 @@ fn test_spy_repo_command_bad_auth() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[ignore] // requires network access to github.com
 fn test_spy_repo_command_bad_command() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");
@@ -55,12 +58,13 @@ fn test_spy_repo_command_bad_command() -> Result<(), Box<dyn std::error::Error>>
     cmd.arg("-c");
     cmd.arg("/notarealcommand");
     cmd.assert()
-        .stderr(predicates::str::contains("/notarealcommand:"));
+        .stdout(predicates::str::contains("/notarealcommand:"));
     cmd.assert().failure().code(127);
     Ok(())
 }
 
 #[test]
+#[ignore] // requires network access to github.com
 fn test_spy_repo_command_bad_command_in_goa_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");
@@ -69,12 +73,13 @@ fn test_spy_repo_command_bad_command_in_goa_file() -> Result<(), Box<dyn std::er
     cmd.arg("-v");
     cmd.arg("3");
     cmd.assert()
-        .stderr(predicates::str::contains("/notarealcommand:"));
+        .stdout(predicates::str::contains("/notarealcommand:"));
     cmd.assert().failure().code(127);
     Ok(())
 }
 
 #[test]
+#[ignore] // requires network access to github.com
 fn test_spy_repo_command_bad_branch() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");
@@ -143,6 +148,7 @@ fn test_spy_repo_command_good_start() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[test]
+#[ignore] // requires network access to github.com
 fn test_spy_repo_command_catch_diff() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("goa")?;
     cmd.arg("spy");


### PR DESCRIPTION
## Summary

- **Tracing (#143):** Replace `log`/`env_logger` with `tracing`/`tracing-subscriber`. Add `--json` flag to both `spy` and `radicle` subcommands for structured JSON log output. Migrate ~15 `eprintln!` calls to `error!`/`warn!` macros. Supports `RUST_LOG` env var override via `EnvFilter`.
- **Retry with backoff (#144):** Add generic `retry_with_backoff` helper with exponential backoff (capped at 30s). Applied to git clone, Radicle HTTP API calls (`fetch_repo_info`, `fetch_patches`), and LEI HTTP requests. Default: 3 retries, 500ms base delay.
- **Test fixture decoupling (#146):** Mark 9 network-dependent tests (clone from `kitplummer/goa_tester`) with `#[ignore]`. Add 5 new local git fixture tests using `git2::Repository::init()`. Add `make test-all` target for CI that includes ignored tests.

Also includes prior commit: graceful shutdown via `ctrlc`, env var sanitization, env-based config for secrets, and release profile optimization.

## Test plan

- [x] `cargo test` — 42 pass (32 unit + 10 integration), 9 network tests ignored
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo build` — clean build
- [ ] `make test-all` — run with network access to verify ignored tests still pass
- [ ] `goa spy <url> --json` — verify JSON structured log output
- [ ] `goa spy <url> -v 2` — verify tracing output with debug level

Closes #143, #144, #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)